### PR TITLE
Fix performance table handling

### DIFF
--- a/reporting/report_generator.py
+++ b/reporting/report_generator.py
@@ -1,8 +1,9 @@
+import os
 from pandas import DataFrame
 
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import letter
-from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph
+from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph, PageBreak
 from reportlab.lib.styles import getSampleStyleSheet
 
 from .utils import convert_to_eat, ffloat, fpos
@@ -24,13 +25,16 @@ class ReportGenerator:
             base = "-".join(parts) if parts else "trading_system_report"
             filename = f"reports/{base}.pdf"
 
+        # Ensure the reports directory exists in case a custom filename is used
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
+
         doc = SimpleDocTemplate(filename, pagesize=letter)
         elements = []
 
         # Title
         elements.append(Paragraph("Trading System Optimization Report", self.styles['Title']))
 
-        for strategy_name, result in best_results.items():
+        for idx, (strategy_name, result) in enumerate(best_results.items()):
             elements.append(Paragraph(f"Strategy: {strategy_name}", self.styles['Heading2']))
             
             # Parameters table
@@ -54,56 +58,75 @@ class ReportGenerator:
             ]))
             elements.append(param_table)
 
-            # Performance table
-            perf_data = [['Metric', 'Value']] + list(result['performance'].items())
-            perf_table = Table(perf_data)
-            perf_table.setStyle(TableStyle([
-                ('BACKGROUND', (0, 0), (-1, 0), colors.grey),
-                ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
-                ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
-                ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-                ('FONTSIZE', (0, 0), (-1, 0), 14),
-                ('BOTTOMPADDING', (0, 0), (-1, 0), 12),
-                ('BACKGROUND', (0, 1), (-1, -1), colors.beige),
-                ('TEXTCOLOR', (0, 1), (-1, -1), colors.black),
-                ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
-                ('FONTNAME', (0, 0), (-1, -1), 'Helvetica'),
-                ('FONTSIZE', (0, 0), (-1, -1), 12),
-                ('TOPPADDING', (0, 0), (-1, -1), 6),
-                ('BOTTOMPADDING', (0, 0), (-1, -1), 6),
-                ('GRID', (0, 0), (-1, -1), 1, colors.black)
-            ]))
-            elements.append(perf_table)
+            # Performance tables
+            perf_sections = []
+            if 'performance' in result:
+                perf_sections.append(('Performance', result['performance']))
+            else:
+                if 'train_performance' in result:
+                    perf_sections.append(('Train Performance', result['train_performance']))
+                if 'test_performance' in result:
+                    perf_sections.append(('Test Performance', result['test_performance']))
+
+            for heading, perf in perf_sections:
+                elements.append(Paragraph(heading, self.styles['Heading3']))
+                perf_data = [['Metric', 'Value']] + list(perf.items())
+                perf_table = Table(perf_data)
+                perf_table.setStyle(TableStyle([
+                    ('BACKGROUND', (0, 0), (-1, 0), colors.grey),
+                    ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
+                    ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
+                    ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+                    ('FONTSIZE', (0, 0), (-1, 0), 14),
+                    ('BOTTOMPADDING', (0, 0), (-1, 0), 12),
+                    ('BACKGROUND', (0, 1), (-1, -1), colors.beige),
+                    ('TEXTCOLOR', (0, 1), (-1, -1), colors.black),
+                    ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
+                    ('FONTNAME', (0, 0), (-1, -1), 'Helvetica'),
+                    ('FONTSIZE', (0, 0), (-1, -1), 12),
+                    ('TOPPADDING', (0, 0), (-1, -1), 6),
+                    ('BOTTOMPADDING', (0, 0), (-1, -1), 6),
+                    ('GRID', (0, 0), (-1, -1), 1, colors.black)
+                ]))
+                elements.append(perf_table)
             
-        # Trades table
-        if 'trades' in result:
-            elements.append(Paragraph("Trades", self.styles['Heading2']))
-            trade_data = [['Entry Time', 'Entry Price', 'Position', 'Exit Time', 'Exit Price', 'PROFIT/LOSS', 'Size', "CAPITAL"]] + [
-                [convert_to_eat(trade['entry_time']), ffloat(trade['entry_price']), fpos(trade['position']), convert_to_eat(trade['exit_time']), ffloat(trade['exit_price']), ffloat(trade['profit_loss']), ffloat(trade['size']), ffloat(trade['remaining_capital'])]
-                for trade in result['trades']
-            ]
-            trade_table = Table(trade_data)
-            trade_table.setStyle(TableStyle([
-                ('BACKGROUND', (0, 0), (-1, 0), colors.grey),
-                ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
-                ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
-                ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-                ('FONTSIZE', (0, 0), (-1, 0), 14),
-                ('BOTTOMPADDING', (0, 0), (-1, 0), 12),
-                ('BACKGROUND', (0, 1), (-1, -1), colors.beige),
-                ('TEXTCOLOR', (0, 1), (-1, -1), colors.black),
-                ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
-                ('FONTNAME', (0, 0), (-1, -1), 'Helvetica'),
-                ('FONTSIZE', (0, 0), (-1, -1), 12),
-                ('TOPPADDING', (0, 0), (-1, -1), 6),
-                ('BOTTOMPADDING', (0, 0), (-1, -1), 6),
-                ('GRID', (0, 0), (-1, -1), 1, colors.black)
-            ]))
-            elements.append(trade_table)
-            try:
-                DataFrame(result["trades"]).to_csv("./data/trades.csv", index=False)
-            except Exception:
-                print("Failed to save trades")
+            # Trades table
+            if 'trades' in result:
+                elements.append(Paragraph("Trades", self.styles['Heading2']))
+                trade_data = [['Entry Time', 'Entry Price', 'Position', 'Exit Time', 'Exit Price', 'PROFIT/LOSS', 'Size', "CAPITAL"]] + [
+                    [convert_to_eat(trade['entry_time']), ffloat(trade['entry_price']), fpos(trade['position']), convert_to_eat(trade['exit_time']), ffloat(trade['exit_price']), ffloat(trade['profit_loss']), ffloat(trade['size']), ffloat(trade['remaining_capital'])]
+                    for trade in result['trades']
+                ]
+
+                # Fit table columns to the available page width
+                col_width = doc.width / len(trade_data[0])
+                trade_table = Table(trade_data, colWidths=[col_width] * len(trade_data[0]))
+
+                trade_table.setStyle(TableStyle([
+                    ('BACKGROUND', (0, 0), (-1, 0), colors.grey),
+                    ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
+                    ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
+                    ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+                    ('FONTSIZE', (0, 0), (-1, 0), 10),
+                    ('BOTTOMPADDING', (0, 0), (-1, 0), 8),
+                    ('BACKGROUND', (0, 1), (-1, -1), colors.beige),
+                    ('TEXTCOLOR', (0, 1), (-1, -1), colors.black),
+                    ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
+                    ('FONTNAME', (0, 1), (-1, -1), 'Helvetica'),
+                    ('FONTSIZE', (0, 1), (-1, -1), 8),
+                    ('TOPPADDING', (0, 0), (-1, -1), 4),
+                    ('BOTTOMPADDING', (0, 0), (-1, -1), 4),
+                    ('GRID', (0, 0), (-1, -1), 1, colors.black)
+                ]))
+                elements.append(trade_table)
+                try:
+                    DataFrame(result["trades"]).to_csv("./data/trades.csv", index=False)
+                except Exception:
+                    print("Failed to save trades")
+
+            # Add a page break between strategies
+            if idx < len(best_results) - 1:
+                elements.append(PageBreak())
 
         doc.build(elements)
         print(f"Report generated: {filename}")


### PR DESCRIPTION
## Summary
- handle results with train/test performance metrics in report generator
- ensure multiple performance tables have subheadings
- tighten the trade table layout to fit the page

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847147fd37483218788a64ab56b24ba