### PR TITLE
Add websocket live trading support

### DIFF
--- a/live_trading/__init__.py
+++ b/live_trading/__init__.py
@@ -1,0 +1,5 @@
+from .live_trader import LiveTrader
+from .websocket_feed import websocket_candle_feed
+from .trade_recorder import TradeRecorder
+
+__all__ = ["LiveTrader", "websocket_candle_feed", "TradeRecorder"]

--- a/live_trading/live_trader.py
+++ b/live_trading/live_trader.py
@@ -1,0 +1,53 @@
+import asyncio
+import pandas as pd
+
+
+class LiveTrader:
+    """Simple live trading engine using incremental candles.
+
+    The trader expects ``data_feed`` to be an **asynchronous** iterator
+    yielding single-row ``pandas.DataFrame`` objects.  This allows it to be
+    connected directly to a websocket feed.
+    """
+
+    def __init__(self, data_feed, strategy_manager, strategy, sleep_time=1.0):
+        """Initialize the trader.
+
+        Parameters
+        ----------
+        data_feed : async iterator
+            Asynchronous iterator yielding ``pandas.DataFrame`` objects containing
+            a single OHLCV row indexed by timestamp.  A convenient way to obtain
+            such iterator is ``websocket_candle_feed`` from ``websocket_feed``.
+        strategy_manager : StrategyManager
+            Manager used to process trades.
+        strategy : Strategy
+            Strategy instance used to generate signals.
+        sleep_time : float
+            Seconds to wait between processing new candles when ``run`` is used.
+        """
+        self.data_feed = data_feed
+        self.strategy_manager = strategy_manager
+        self.strategy = strategy
+        self.sleep_time = sleep_time
+        self.data = pd.DataFrame(columns=['open', 'high', 'low', 'close', 'volume'])
+
+    async def step(self):
+        """Process the next candle from the feed.  Returns ``False`` when the
+        feed is exhausted."""
+        try:
+            new_candle = await anext(self.data_feed)
+        except StopAsyncIteration:
+            return False
+
+        self.data = pd.concat([self.data, new_candle])
+        signals = self.strategy.generate_signals(self.data)
+        new_signals = signals.loc[new_candle.index]
+        self.strategy_manager.data = self.data
+        self.strategy_manager.execute_signals(new_signals, self.strategy)
+        return True
+
+    async def run(self):
+        """Continuously process candles until the feed is exhausted."""
+        while await self.step():
+            await asyncio.sleep(self.sleep_time)

--- a/live_trading/trade_recorder.py
+++ b/live_trading/trade_recorder.py
@@ -1,0 +1,95 @@
+import sqlite3
+from typing import Iterable
+
+from strategy_manager import Trade
+
+class TradeRecorder:
+    """Persist trades to a SQLite database."""
+
+    def __init__(self, db_path: str = "trades.db"):
+        self.conn = sqlite3.connect(db_path)
+        self._init_db()
+        self._recorded = set()
+
+    def _init_db(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS trades(
+                entry_time TEXT PRIMARY KEY,
+                entry_price REAL,
+                position INTEGER,
+                exit_time TEXT,
+                exit_price REAL,
+                profit_loss REAL,
+                stop_loss REAL,
+                take_profit REAL,
+                size REAL,
+                remaining_capital REAL
+            )
+            """
+        )
+        self.conn.commit()
+
+    def sync(self, trades: Iterable[Trade]) -> None:
+        """Sync the given trades with the database."""
+        for trade in trades:
+            key = trade.entry_time
+            if key not in self._recorded:
+                self._insert_trade(trade)
+                self._recorded.add(key)
+            elif trade.exit_time is not None:
+                self._update_trade(trade)
+
+    def _insert_trade(self, trade: Trade) -> None:
+        data = trade.get_data()
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            INSERT OR IGNORE INTO trades(
+                entry_time, entry_price, position,
+                exit_time, exit_price, profit_loss,
+                stop_loss, take_profit, size,
+                remaining_capital
+            ) VALUES(?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                data["entry_time"],
+                data["entry_price"],
+                data["position"],
+                data["exit_time"],
+                data["exit_price"],
+                data["profit_loss"],
+                data["stop_loss"],
+                data["take_profit"],
+                data["size"],
+                data["remaining_capital"],
+            ),
+        )
+        self.conn.commit()
+
+    def _update_trade(self, trade: Trade) -> None:
+        data = trade.get_data()
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            UPDATE trades SET
+                exit_time=?,
+                exit_price=?,
+                profit_loss=?,
+                remaining_capital=?
+            WHERE entry_time=?
+            """,
+            (
+                data["exit_time"],
+                data["exit_price"],
+                data["profit_loss"],
+                data["remaining_capital"],
+                data["entry_time"],
+            ),
+        )
+        self.conn.commit()
+
+    def close(self) -> None:
+        self.conn.close()
+

--- a/live_trading/websocket_feed.py
+++ b/live_trading/websocket_feed.py
@@ -1,0 +1,44 @@
+import json
+import pandas as pd
+import websockets
+
+async def websocket_candle_feed(url):
+    """Yield candle data from a websocket stream.
+
+    The helper understands two JSON formats:
+
+    1. Generic messages with ``timestamp``/``open``/``high``/``low``/``close``/
+       ``volume`` fields.
+    2. Binance kline messages as produced by futures or spot websocket streams
+       (``data`` → ``k``).  Only closed candles (``x`` is ``True``) are yielded.
+    """
+
+    async with websockets.connect(url) as ws:
+        async for message in ws:
+            data = json.loads(message)
+
+            # Binance kline format
+            if isinstance(data, dict) and 'data' in data and 'k' in data['data']:
+                kline = data['data']['k']
+                if not kline.get('x'):
+                    # ignore partial candles
+                    continue
+                timestamp = pd.to_datetime(kline['T'], unit='ms')
+                df = pd.DataFrame({
+                    'open': [float(kline['o'])],
+                    'high': [float(kline['h'])],
+                    'low': [float(kline['l'])],
+                    'close': [float(kline['c'])],
+                    'volume': [float(kline['v'])]
+                }, index=[timestamp])
+            else:
+                timestamp = pd.to_datetime(data['timestamp'])
+                df = pd.DataFrame({
+                    'open': [data['open']],
+                    'high': [data['high']],
+                    'low': [data['low']],
+                    'close': [data['close']],
+                    'volume': [data['volume']]
+                }, index=[timestamp])
+
+            yield df

--- a/run_live_trader.py
+++ b/run_live_trader.py
@@ -1,0 +1,32 @@
+import asyncio
+import pandas as pd
+
+from strategies import EMACrossover
+from strategy_manager import StrategyManager
+from live_trading import LiveTrader, websocket_candle_feed, TradeRecorder
+
+
+def build_trader(url: str) -> tuple[LiveTrader, TradeRecorder]:
+    feed = websocket_candle_feed(url)
+    strategy = EMACrossover(short_window=9, long_window=21,
+                            stop_loss_pct=0.02, take_profit_pct=0.04)
+    manager = StrategyManager(pd.DataFrame(columns=['open', 'high', 'low', 'close', 'volume']),
+                              initial_capital=1000, risk_per_trade=0.01)
+    trader = LiveTrader(feed, manager, strategy)
+    recorder = TradeRecorder("trades.db")
+    return trader, recorder
+
+
+async def main() -> None:
+    url = "wss://fstream.binance.com/stream?streams=btcusdt@kline_4h"
+    trader, recorder = build_trader(url)
+    try:
+        while await trader.step():
+            recorder.sync(trader.strategy_manager.trades)
+            await asyncio.sleep(trader.sleep_time)
+    finally:
+        recorder.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/strategy_manager.py
+++ b/strategy_manager.py
@@ -78,6 +78,37 @@ class StrategyManager:
             elif signal == TradeAction.EXIT and self.current_position != Position.NEUTRAL:
                 self.exit_trade(timestamp)
 
+    def execute_signals(self, signals, strategy):
+        """Execute a precomputed set of signals.
+
+        This method mirrors ``execute_strategy`` but operates on a series of
+        signals that are already calculated.  It is useful for live trading
+        where new signals are produced incrementally.
+        """
+        for timestamp, signal in signals.items():
+            high_price = self.data.loc[timestamp, 'high']
+            low_price = self.data.loc[timestamp, 'low']
+
+            # Check for stop-loss or take-profit
+            if self.current_position != Position.NEUTRAL:
+                current_trade = self.trades[-1]
+                if self.current_position == Position.LONG:
+                    if low_price <= current_trade.stop_loss or high_price >= current_trade.take_profit:
+                        self.exit_trade(timestamp)
+                elif self.current_position == Position.SHORT:
+                    if high_price >= current_trade.stop_loss or low_price <= current_trade.take_profit:
+                        self.exit_trade(timestamp)
+
+            # Process signal
+            if signal == TradeAction.ENTER_LONG and self.current_position != Position.LONG:
+                if self.trade_mode in (TradeMode.BOTH, TradeMode.LONG_ONLY):
+                    self.enter_trade(timestamp, Position.LONG, strategy.stop_loss_pct, strategy.take_profit_pct)
+            elif signal == TradeAction.ENTER_SHORT and self.current_position != Position.SHORT:
+                if self.trade_mode in (TradeMode.BOTH, TradeMode.SHORT_ONLY):
+                    self.enter_trade(timestamp, Position.SHORT, strategy.stop_loss_pct, strategy.take_profit_pct)
+            elif signal == TradeAction.EXIT and self.current_position != Position.NEUTRAL:
+                self.exit_trade(timestamp)
+
     def enter_trade(self, timestamp, position, stop_loss_pct, take_profit_pct):
         if self.current_position == position:
             # Already in the same position, no action needed
@@ -96,6 +127,7 @@ class StrategyManager:
             take_profit = entry_price * (1 - take_profit_pct)
         
         size = self.risk_based_position_sizing(entry_price, stop_loss)
+        # Entry details: price=entry_price, stop_loss=stop_loss, take_profit=take_profit, size=size
         self.trades.append(Trade(timestamp, entry_price, position, stop_loss, take_profit, size))
 
     def exit_trade(self, timestamp):

--- a/tests/test_live_trader.py
+++ b/tests/test_live_trader.py
@@ -1,0 +1,165 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from datetime import datetime
+import pandas as pd
+
+from strategy_manager import StrategyManager
+from utils.enums import TradeAction
+import asyncio
+import json
+import websockets
+from live_trading.live_trader import LiveTrader
+from live_trading.websocket_feed import websocket_candle_feed
+from live_trading.trade_recorder import TradeRecorder
+
+class DummyStrategy:
+    def __init__(self):
+        self.stop_loss_pct = 0.1
+        self.take_profit_pct = 0.2
+
+    def generate_signals(self, data):
+        signals = pd.Series(TradeAction.EXIT.value, index=data.index)
+        if len(signals) > 0:
+            signals.iloc[0] = TradeAction.ENTER_LONG.value
+        if len(signals) > 1:
+            signals.iloc[1] = TradeAction.EXIT.value
+        return signals
+
+def make_data():
+    index = [datetime(2024,1,1), datetime(2024,1,2)]
+    return pd.DataFrame({
+        'open':[100,110],
+        'high':[105,112],
+        'low':[95,108],
+        'close':[100,110],
+        'volume':[1000,1000]
+    }, index=index)
+
+
+async def data_stream(df):
+    for i in range(len(df)):
+        yield df.iloc[i:i+1]
+        await asyncio.sleep(0)
+
+def test_live_trader_matches_offline():
+    data = make_data()
+    offline_sm = StrategyManager(data, initial_capital=100, risk_per_trade=0.1)
+    offline_sm.execute_strategy(DummyStrategy())
+    expected = [(t.entry_time, t.exit_time, t.profit_loss) for t in offline_sm.trades]
+
+    sm = StrategyManager(pd.DataFrame(columns=data.columns), initial_capital=100, risk_per_trade=0.1)
+    trader = LiveTrader(data_stream(data), sm, DummyStrategy(), sleep_time=0)
+
+    asyncio.run(trader.run())
+    result = [(t.entry_time, t.exit_time, t.profit_loss) for t in sm.trades]
+
+    assert result == expected
+
+
+async def websocket_server(data, port):
+    async def handler(ws):
+        for ts, row in data.iterrows():
+            msg = json.dumps({
+                'timestamp': ts.isoformat(),
+                'open': float(row.open),
+                'high': float(row.high),
+                'low': float(row.low),
+                'close': float(row.close),
+                'volume': int(row.volume),
+            })
+            await ws.send(msg)
+        await ws.close()
+    return await websockets.serve(handler, 'localhost', port)
+
+
+def test_websocket_live_trader():
+    data = make_data()
+    offline_sm = StrategyManager(data, initial_capital=100, risk_per_trade=0.1)
+    offline_sm.execute_strategy(DummyStrategy())
+    expected = [(t.entry_time, t.exit_time, t.profit_loss) for t in offline_sm.trades]
+
+    async def run_case():
+        port = 8765
+        server = await websocket_server(data, port)
+        feed = websocket_candle_feed(f"ws://localhost:{port}")
+        sm = StrategyManager(pd.DataFrame(columns=data.columns), initial_capital=100, risk_per_trade=0.1)
+        trader = LiveTrader(feed, sm, DummyStrategy(), sleep_time=0)
+        await trader.run()
+        server.close()
+        await server.wait_closed()
+        result = [(t.entry_time, t.exit_time, t.profit_loss) for t in sm.trades]
+        return result
+
+    result = asyncio.run(run_case())
+    assert result == expected
+
+
+async def binance_server(data, port):
+    async def handler(ws):
+        for ts, row in data.iterrows():
+            msg = json.dumps({
+                "stream": "btcusdt@kline_4h",
+                "data": {
+                    "e": "kline",
+                    "E": 0,
+                    "s": "BTCUSDT",
+                    "k": {
+                        "t": int(ts.timestamp() * 1000),
+                        "T": int(ts.timestamp() * 1000),
+                        "s": "BTCUSDT",
+                        "i": "4h",
+                        "f": 0,
+                        "L": 0,
+                        "o": str(row.open),
+                        "c": str(row.close),
+                        "h": str(row.high),
+                        "l": str(row.low),
+                        "v": str(row.volume),
+                        "n": 0,
+                        "x": True,
+                        "q": "0",
+                        "V": "0",
+                        "Q": "0",
+                        "B": "0",
+                    },
+                },
+            })
+            await ws.send(msg)
+        await ws.close()
+
+    return await websockets.serve(handler, "localhost", port)
+
+
+def test_websocket_feed_binance_format():
+    data = make_data().iloc[:1]
+
+    async def run_case():
+        port = 8899
+        server = await binance_server(data, port)
+        feed = websocket_candle_feed(f"ws://localhost:{port}")
+        candle = await anext(feed)
+        server.close()
+        await server.wait_closed()
+        return candle
+
+    candle = asyncio.run(run_case())
+    pd.testing.assert_frame_equal(candle, data)
+
+
+def test_trade_recorder():
+    data = make_data()
+
+    async def run_case():
+        sm = StrategyManager(pd.DataFrame(columns=data.columns), initial_capital=100, risk_per_trade=0.1)
+        recorder = TradeRecorder(":memory:")
+        trader = LiveTrader(data_stream(data), sm, DummyStrategy(), sleep_time=0)
+        while await trader.step():
+            recorder.sync(sm.trades)
+        cur = recorder.conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM trades")
+        count = cur.fetchone()[0]
+        recorder.close()
+        return count
+
+    count = asyncio.run(run_case())
+    assert count == 1


### PR DESCRIPTION
## Summary
- support async candle feeds via websocket
- comment entry info when entering trades
- provide websocket_candle_feed helper
- add trade recorder for SQLite logging
- create example live trader runner
- test websocket trader behavior and trade recorder

## Testing
- `pip install -q -r requirements.txt` *(fails: ModuleNotFoundError)*
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684736e585d08321afc76c9030e2fc97