### PR TITLE
Add historical warm-up for live trading

### DIFF
--- a/data/data_loader.py
+++ b/data/data_loader.py
@@ -13,3 +13,11 @@ class DataLoader:
         df = df[['open', 'high', 'low', 'close', 'volume']].astype("float")
         # df.to_csv("./data/data.csv")
         return df
+
+    def fetch_recent_data(self, symbol, interval, limit):
+        """Fetch the most recent candles for ``symbol``."""
+        klines = self.client.get_klines(symbol=symbol, interval=interval, limit=limit)
+        df = pd.DataFrame(klines, columns=['timestamp', 'open', 'high', 'low', 'close', 'volume', 'close_time', 'quote_asset_volume', 'number_of_trades', 'taker_buy_base_asset_volume', 'taker_buy_quote_asset_volume', 'ignore'])
+        df['timestamp'] = pd.to_datetime(df['timestamp'], unit='ms')
+        df.set_index('timestamp', inplace=True)
+        return df[['open', 'high', 'low', 'close', 'volume']].astype(float)

--- a/live_trading/__init__.py
+++ b/live_trading/__init__.py
@@ -1,6 +1,6 @@
 from .live_trader import LiveTrader
-from .websocket_feed import websocket_candle_feed
+from .websocket_feed import websocket_candle_feed, prepend_historical_data
 from .trade_recorder import TradeRecorder
 
-__all__ = ["LiveTrader", "websocket_candle_feed", "TradeRecorder"]
+__all__ = ["LiveTrader", "websocket_candle_feed", "prepend_historical_data", "TradeRecorder"]
 

--- a/live_trading/live_trader.py
+++ b/live_trading/live_trader.py
@@ -10,7 +10,7 @@ class LiveTrader:
     connected directly to a websocket feed.
     """
 
-    def __init__(self, data_feed, strategy_manager, strategy, sleep_time=1.0):
+    def __init__(self, data_feed, strategy_manager, strategy, sleep_time=1.0, initial_data=None):
         """Initialize the trader.
 
         Parameters
@@ -33,7 +33,14 @@ class LiveTrader:
         self.strategy_manager = strategy_manager
         self.strategy = strategy
         self.sleep_time = sleep_time
-        self.data = pd.DataFrame(columns=['open', 'high', 'low', 'close', 'volume'])
+
+        if initial_data is None:
+            self.data = pd.DataFrame(columns=['open', 'high', 'low', 'close', 'volume'])
+        else:
+            self.data = initial_data.copy()
+            # Expose historical candles to the strategy manager so that
+            # position sizing and exits can reference the same dataset.
+            self.strategy_manager.data = self.data
 
     async def step(self):
         """Process the next candle from the feed.

--- a/live_trading/websocket_feed.py
+++ b/live_trading/websocket_feed.py
@@ -41,3 +41,24 @@ async def websocket_candle_feed(url):
                 }, index=[timestamp])
 
             yield df, closed
+
+
+async def prepend_historical_data(historical_df, live_feed):
+    """Yield candles from ``historical_df`` before ``live_feed``.
+
+    Parameters
+    ----------
+    historical_df : pandas.DataFrame
+        DataFrame containing OHLCV data indexed by timestamp.  Each row is
+        yielded as a closed candle.
+    live_feed : async iterator
+        Asynchronous iterator yielding ``(DataFrame, closed)`` tuples – e.g.
+        :func:`websocket_candle_feed`.
+    """
+    for ts, row in historical_df.iterrows():
+        df = pd.DataFrame(row).T
+        df.index = pd.DatetimeIndex([ts])
+        yield df, True
+
+    async for candle, closed in live_feed:
+        yield candle, closed

--- a/run_live_trader.py
+++ b/run_live_trader.py
@@ -3,16 +3,20 @@ import pandas as pd
 
 from strategies import EMACrossover
 from strategy_manager import StrategyManager
-from live_trading import LiveTrader, websocket_candle_feed, TradeRecorder
+from live_trading import LiveTrader, websocket_candle_feed, prepend_historical_data, TradeRecorder
+from data import DataLoader
+from config import BINANCE_API_KEY, BINANCE_API_SECRET
+from binance.client import Client
 
 
-def build_trader(url: str) -> tuple[LiveTrader, TradeRecorder]:
-    feed = websocket_candle_feed(url)
+def build_trader(url: str, history_limit: int = 50) -> tuple[LiveTrader, TradeRecorder]:
+    loader = DataLoader(BINANCE_API_KEY, BINANCE_API_SECRET)
+    historical = loader.fetch_recent_data("BTCUSDT", Client.KLINE_INTERVAL_4HOUR, history_limit)
+    feed = prepend_historical_data(historical, websocket_candle_feed(url))
     strategy = EMACrossover(short_window=3, long_window=21,
                             stop_loss_pct=6, take_profit_pct=3)
-    manager = StrategyManager(pd.DataFrame(columns=['open', 'high', 'low', 'close', 'volume']),
-                              initial_capital=1000, risk_per_trade=0.01)
-    trader = LiveTrader(feed, manager, strategy)
+    manager = StrategyManager(historical.copy(), initial_capital=1000, risk_per_trade=0.01)
+    trader = LiveTrader(feed, manager, strategy, initial_data=historical)
     recorder = TradeRecorder("trades.db")
     return trader, recorder
 

--- a/tests/test_live_trader.py
+++ b/tests/test_live_trader.py
@@ -12,6 +12,22 @@ from live_trading.live_trader import LiveTrader
 from live_trading.websocket_feed import websocket_candle_feed
 from live_trading.trade_recorder import TradeRecorder
 
+
+class HistoryDependentStrategy:
+    """Strategy that only starts generating signals once three candles are present."""
+
+    def __init__(self):
+        self.stop_loss_pct = 0.1
+        self.take_profit_pct = 0.2
+
+    def generate_signals(self, data):
+        signals = pd.Series(TradeAction.EXIT.value, index=data.index)
+        if len(data) >= 3:
+            signals.iloc[2] = TradeAction.ENTER_LONG.value
+        if len(data) >= 4:
+            signals.iloc[3] = TradeAction.EXIT.value
+        return signals
+
 class DummyStrategy:
     def __init__(self):
         self.stop_loss_pct = 0.1
@@ -33,6 +49,17 @@ def make_data():
         'low':[95,108],
         'close':[100,110],
         'volume':[1000,1000]
+    }, index=index)
+
+
+def make_long_data():
+    index = [datetime(2024, 1, 1), datetime(2024, 1, 2), datetime(2024, 1, 3), datetime(2024, 1, 4)]
+    return pd.DataFrame({
+        'open': [100, 105, 110, 115],
+        'high': [105, 110, 115, 120],
+        'low': [95, 100, 105, 110],
+        'close': [100, 108, 112, 118],
+        'volume': [1000, 1000, 1000, 1000]
     }, index=index)
 
 
@@ -190,4 +217,27 @@ def test_partial_candle_exit():
     trade = asyncio.run(run_case())
     assert trade.exit_price == 90
     assert trade.exit_time == data.index[1]
+
+
+def test_live_trader_with_initial_data():
+    data = make_long_data()
+    history = data.iloc[:2]
+    live = data.iloc[2:]
+
+    # Offline run on full data
+    offline_sm = StrategyManager(data, initial_capital=100, risk_per_trade=0.1)
+    offline_sm.execute_strategy(HistoryDependentStrategy())
+    expected = [(t.entry_time, t.exit_time) for t in offline_sm.trades]
+
+    async def feed():
+        for i in range(len(live)):
+            yield live.iloc[i:i+1], True
+            await asyncio.sleep(0)
+
+    sm = StrategyManager(history.copy(), initial_capital=100, risk_per_trade=0.1)
+    trader = LiveTrader(feed(), sm, HistoryDependentStrategy(), sleep_time=0, initial_data=history)
+    asyncio.run(trader.run())
+
+    result = [(t.entry_time, t.exit_time) for t in sm.trades]
+    assert result == expected
 


### PR DESCRIPTION
## Summary
- fetch recent candles using new `DataLoader.fetch_recent_data`
- allow `LiveTrader` to accept initial historical data
- combine historical data with websocket feed using `prepend_historical_data`
- update live trading script to warm up strategies with recent klines
- export new helper and test live trader with initial data

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847461dfb1c83219fc30000145843f0