### PR TITLE
Normalize stop-loss/take-profit units

### DIFF
--- a/config.py
+++ b/config.py
@@ -26,8 +26,9 @@ STRATEGY_PARAMS = {
     'macd_fast_length': 9,
     'macd_slow_length': 16,
     'macd_signal_length': 3,
-    'stop_loss_pct': 0.01,
-    'take_profit_pct': 0.0529
+    # Stop-loss and take-profit expressed in percentages (1 = 1%)
+    'stop_loss_pct': 1,
+    'take_profit_pct': 5.29
 }
 
 # Risk management parameters

--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -24,8 +24,9 @@ class DummyOptimizer:
 
 class DummyStrategy:
     def __init__(self, p):
-        self.stop_loss_pct = 0.1
-        self.take_profit_pct = 0.2
+        # store as decimal from percentage inputs
+        self.stop_loss_pct = 10 / 100
+        self.take_profit_pct = 20 / 100
     def generate_signals(self, data):
         return pd.Series({data.index[0]: TradeAction.ENTER_LONG.value,
                           data.index[-1]: TradeAction.EXIT.value})

--- a/tests/test_live_trader.py
+++ b/tests/test_live_trader.py
@@ -17,8 +17,8 @@ class HistoryDependentStrategy:
     """Strategy that only starts generating signals once three candles are present."""
 
     def __init__(self):
-        self.stop_loss_pct = 0.1
-        self.take_profit_pct = 0.2
+        self.stop_loss_pct = 10 / 100
+        self.take_profit_pct = 20 / 100
 
     def generate_signals(self, data):
         signals = pd.Series(TradeAction.EXIT.value, index=data.index)
@@ -30,8 +30,8 @@ class HistoryDependentStrategy:
 
 class DummyStrategy:
     def __init__(self):
-        self.stop_loss_pct = 0.1
-        self.take_profit_pct = 0.2
+        self.stop_loss_pct = 10 / 100
+        self.take_profit_pct = 20 / 100
 
     def generate_signals(self, data):
         signals = pd.Series(TradeAction.EXIT.value, index=data.index)

--- a/tests/test_strategy_manager.py
+++ b/tests/test_strategy_manager.py
@@ -7,16 +7,17 @@ from utils.enums import TradeAction, TradeMode, Position
 
 class DummyStrategy:
     def __init__(self):
-        self.stop_loss_pct = 0.10
-        self.take_profit_pct = 0.20
+        # inputs provided in percentages
+        self.stop_loss_pct = 10 / 100
+        self.take_profit_pct = 20 / 100
     def generate_signals(self, data):
         return pd.Series({data.index[0]: TradeAction.ENTER_LONG.value,
                            data.index[1]: TradeAction.EXIT.value})
 
 class LongShortStrategy:
     def __init__(self):
-        self.stop_loss_pct = 0.1
-        self.take_profit_pct = 0.2
+        self.stop_loss_pct = 10 / 100
+        self.take_profit_pct = 20 / 100
 
     def generate_signals(self, data):
         return pd.Series({

--- a/trades_finder.py
+++ b/trades_finder.py
@@ -71,11 +71,11 @@ def main():
 
         # Calculate stop loss and take profit prices
         if current_signal == TradeAction.ENTER_LONG.value:
-            stop_loss_price = entry_price * (1 - STRATEGY_PARAMS['stop_loss_pct'])
-            take_profit_price = entry_price * (1 + STRATEGY_PARAMS['take_profit_pct'])
+            stop_loss_price = entry_price * (1 - STRATEGY_PARAMS['stop_loss_pct'] / 100)
+            take_profit_price = entry_price * (1 + STRATEGY_PARAMS['take_profit_pct'] / 100)
         elif current_signal == TradeAction.ENTER_SHORT.value:
-            stop_loss_price = entry_price * (1 + STRATEGY_PARAMS['stop_loss_pct'])
-            take_profit_price = entry_price * (1 - STRATEGY_PARAMS['take_profit_pct'])
+            stop_loss_price = entry_price * (1 + STRATEGY_PARAMS['stop_loss_pct'] / 100)
+            take_profit_price = entry_price * (1 - STRATEGY_PARAMS['take_profit_pct'] / 100)
 
         # Calculate position size
         position_size = risk_based_position_sizing(


### PR DESCRIPTION
## Summary
- ensure stop-loss and take-profit values use percentages everywhere
- update example trade finder logic
- adapt tests to new input units

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ced11f208321889819252946f975