### PR TITLE
Fix position sizing for zero stop loss

### DIFF
--- a/strategy_manager.py
+++ b/strategy_manager.py
@@ -204,6 +204,8 @@ class StrategyManager:
     def risk_based_position_sizing(self, entry_price, stop_loss_price):
         risk_amount = self.available_capital * self.risk_per_trade
         stop_loss_distance = abs(entry_price - stop_loss_price)
+        if stop_loss_distance == 0:
+            return 0
         position_size = risk_amount / stop_loss_distance
         max_position_size = self.available_capital / entry_price
         return min(position_size, max_position_size)

--- a/tests/test_strategy_manager.py
+++ b/tests/test_strategy_manager.py
@@ -44,6 +44,12 @@ def test_risk_based_position_sizing():
     assert size == 10
 
 
+def test_risk_based_position_sizing_zero_distance():
+    sm = StrategyManager(None, initial_capital=1000, risk_per_trade=0.1)
+    size = sm.risk_based_position_sizing(100, 100)
+    assert size == 0
+
+
 def test_execute_strategy_basic():
     data = make_data()
     sm = StrategyManager(data, initial_capital=100, risk_per_trade=0.1)

--- a/trades_finder.py
+++ b/trades_finder.py
@@ -125,6 +125,8 @@ def risk_based_position_sizing(available_capital, risk_per_trade, entry_price, s
     """
     risk_amount = available_capital * risk_per_trade
     stop_loss_distance = abs(entry_price - stop_loss_price)
+    if stop_loss_distance == 0:
+        return 0
     position_size = risk_amount / stop_loss_distance
     max_position_size = available_capital / entry_price
     return min(position_size, max_position_size)


### PR DESCRIPTION
## Summary
- avoid dividing by zero when stop loss equals entry price
- check stop loss distance in both StrategyManager and trades_finder helpers
- test edge case for zero stop loss distance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847cf1eca448321bd9be9720943c9d4