### PR TITLE
Fix dtype for strategy signals

### DIFF
--- a/strategies/macd_rsi.py
+++ b/strategies/macd_rsi.py
@@ -13,7 +13,7 @@ class MACD_RSIStrategy(Strategy):
         self.rsi_oversold = float(rsi_oversold)
 
     def generate_signals(self, data):
-        signals = pd.Series(index=data.index)
+        signals = pd.Series(index=data.index, dtype=int)
         signals[:] = TradeAction.EXIT.value
 
         # MACD calculation

--- a/strategies/macd_rsi_cmf.py
+++ b/strategies/macd_rsi_cmf.py
@@ -14,7 +14,7 @@ class MACD_RSI_CMF_Strategy(Strategy):
         self.cmf_window = max(1, int(cmf_window))
 
     def generate_signals(self, data):
-        signals = pd.Series(index=data.index)
+        signals = pd.Series(index=data.index, dtype=int)
         signals[:] = TradeAction.EXIT.value
 
         # MACD calculation

--- a/strategies/moving_average_crossover.py
+++ b/strategies/moving_average_crossover.py
@@ -9,7 +9,7 @@ class MovingAverageCrossover(Strategy):
         self.long_window = max(1, int(long_window))
 
     def generate_signals(self, data):
-        signals = pd.Series(index=data.index)
+        signals = pd.Series(index=data.index, dtype=int)
         signals[:] = TradeAction.EXIT.value
 
         short_ma = data['close'].rolling(window=self.short_window).mean()


### PR DESCRIPTION
## Summary
- standardize signal initialization to use `pd.Series(..., dtype=int)`
- ensure tests still pass

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847cf47562483218ac7d249dae05964