### PR TITLE
Execute trades at next candle open

### DIFF
--- a/live_trading/live_trader.py
+++ b/live_trading/live_trader.py
@@ -54,6 +54,8 @@ class LiveTrader:
             return False
 
         ts = new_candle.index[0]
+        open_price = float(new_candle['open'].iloc[0])
+        self.strategy_manager.process_pending_entry(ts, open_price)
         high = float(new_candle['high'].iloc[0])
         low = float(new_candle['low'].iloc[0])
         self.strategy_manager.check_exit_prices(ts, high, low)

--- a/strategy_manager.py
+++ b/strategy_manager.py
@@ -43,12 +43,17 @@ class StrategyManager:
         self.available_capital = initial_capital
         self.risk_per_trade = risk_per_trade
         self.trade_mode = trade_mode
+        # When running live we might not yet have the next candle available
+        # when a signal is generated.  ``pending_entry`` stores the details of
+        # such trade so it can be opened once the next candle appears.
+        self.pending_entry = None
 
     def reset(self, data, trade_mode=None):
         self.data = data
         self.current_position = Position.NEUTRAL
         self.trades = []
         self.available_capital = self.initial_capital
+        self.pending_entry = None
         if trade_mode is not None:
             self.trade_mode = trade_mode
 
@@ -117,19 +122,14 @@ class StrategyManager:
         elif self.current_position != Position.NEUTRAL:
             self.exit_trade(timestamp)
             
-        self.current_position = position
-        entry_price = self.data.loc[timestamp, 'close']
-        
-        if position == Position.LONG:
-            stop_loss = entry_price * (1 - stop_loss_pct)
-            take_profit = entry_price * (1 + take_profit_pct)
-        elif position == Position.SHORT:
-            stop_loss = entry_price * (1 + stop_loss_pct)
-            take_profit = entry_price * (1 - take_profit_pct)
-        
-        size = self.risk_based_position_sizing(entry_price, stop_loss)
-        # Entry details: price=entry_price, stop_loss=stop_loss, take_profit=take_profit, size=size
-        self.trades.append(Trade(timestamp, entry_price, position, stop_loss, take_profit, size))
+        idx = self.data.index.get_loc(timestamp)
+        if idx + 1 < len(self.data):
+            next_ts = self.data.index[idx + 1]
+            entry_price = self.data.loc[next_ts, 'open']
+            self._open_trade(next_ts, entry_price, position, stop_loss_pct, take_profit_pct)
+        else:
+            # No next candle yet; defer execution until it becomes available
+            self.pending_entry = (position, stop_loss_pct, take_profit_pct)
 
     def exit_trade(self, timestamp):
         if self.current_position == Position.NEUTRAL:
@@ -209,3 +209,25 @@ class StrategyManager:
             entry_price,
             stop_loss_price,
         )
+
+    def _open_trade(self, entry_time, entry_price, position, stop_loss_pct, take_profit_pct):
+        """Helper used to actually create a Trade instance."""
+        self.current_position = position
+        if position == Position.LONG:
+            stop_loss = entry_price * (1 - stop_loss_pct)
+            take_profit = entry_price * (1 + take_profit_pct)
+        else:
+            stop_loss = entry_price * (1 + stop_loss_pct)
+            take_profit = entry_price * (1 - take_profit_pct)
+
+        size = self.risk_based_position_sizing(entry_price, stop_loss)
+        self.trades.append(Trade(entry_time, entry_price, position, stop_loss, take_profit, size))
+
+    def process_pending_entry(self, timestamp, open_price):
+        """Execute any trade that was waiting for the next candle."""
+        if self.pending_entry is None:
+            return
+
+        position, stop_loss_pct, take_profit_pct = self.pending_entry
+        self._open_trade(timestamp, open_price, position, stop_loss_pct, take_profit_pct)
+        self.pending_entry = None

--- a/tests/test_live_trader.py
+++ b/tests/test_live_trader.py
@@ -215,7 +215,7 @@ def test_partial_candle_exit():
         return sm.trades[0]
 
     trade = asyncio.run(run_case())
-    assert trade.exit_price == 90
+    assert trade.exit_price == 99
     assert trade.exit_time == data.index[1]
 
 

--- a/tests/test_strategy_manager.py
+++ b/tests/test_strategy_manager.py
@@ -57,9 +57,9 @@ def test_execute_strategy_basic():
     sm.execute_strategy(DummyStrategy())
     assert len(sm.trades) == 1
     trade = sm.trades[0]
-    assert trade.entry_time == data.index[0]
+    assert trade.entry_time == data.index[1]
     assert trade.exit_time == data.index[1]
-    assert trade.profit_loss == 10
+    assert trade.profit_loss == -10
 
 
 def test_trade_mode_long_only():

--- a/utils/position_sizing.py
+++ b/utils/position_sizing.py
@@ -2,6 +2,8 @@ def risk_based_position_sizing(available_capital, risk_per_trade, entry_price, s
     """Calculate position size based on risk per trade."""
     risk_amount = available_capital * risk_per_trade
     stop_loss_distance = abs(entry_price - stop_loss_price)
+    if stop_loss_distance == 0:
+        return 0
     position_size = risk_amount / stop_loss_distance
     max_position_size = available_capital / entry_price
     return min(position_size, max_position_size)


### PR DESCRIPTION
## Summary
- delay entry execution until the next candle's open
- handle pending entries in live trading
- prevent zero division in risk-based sizing
- adjust unit tests for next-open logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d4e84a0c8321bfb408a64d119f3a