### PR TITLE
Ensure RSI and Bollinger strategies maintain open positions

### DIFF
--- a/strategies/bollinger_bands_strategy.py
+++ b/strategies/bollinger_bands_strategy.py
@@ -9,12 +9,38 @@ class BollingerBandsStrategy(Strategy):
         self.num_std = num_std
 
     def generate_signals(self, data):
-        signals = pd.Series(index=data.index)
+        signals = pd.Series(index=data.index, dtype=int)
         signals[:] = TradeAction.EXIT.value
 
-        bollinger = ta.volatility.BollingerBands(data['close'], window=self.window, window_dev=self.num_std)
-        
-        signals[data['close'] < bollinger.lower_band] = TradeAction.ENTER_LONG.value
-        signals[data['close'] > bollinger.upper_band] = TradeAction.ENTER_SHORT.value
+        bollinger = ta.volatility.BollingerBands(
+            data['close'], window=self.window, window_dev=self.num_std
+        )
+
+        position = TradeAction.EXIT.value
+        mid_band = bollinger.bollinger_mavg()
+        lower_band = bollinger.bollinger_lband()
+        upper_band = bollinger.bollinger_hband()
+
+        for i in range(1, len(data)):
+            long_entry = data['close'].iloc[i] < lower_band.iloc[i]
+            short_entry = data['close'].iloc[i] > upper_band.iloc[i]
+            long_exit = (
+                position == TradeAction.ENTER_LONG.value
+                and data['close'].iloc[i] > mid_band.iloc[i]
+            )
+            short_exit = (
+                position == TradeAction.ENTER_SHORT.value
+                and data['close'].iloc[i] < mid_band.iloc[i]
+            )
+
+            if position == TradeAction.EXIT.value:
+                if long_entry:
+                    position = TradeAction.ENTER_LONG.value
+                elif short_entry:
+                    position = TradeAction.ENTER_SHORT.value
+            elif long_exit or short_exit:
+                position = TradeAction.EXIT.value
+
+            signals.iloc[i] = position
 
         return signals

--- a/strategies/rsi_strategy.py
+++ b/strategies/rsi_strategy.py
@@ -10,12 +10,26 @@ class RSIStrategy(Strategy):
         self.overbought = overbought
 
     def generate_signals(self, data):
-        signals = pd.Series(index=data.index)
+        signals = pd.Series(index=data.index, dtype=int)
         signals[:] = TradeAction.EXIT.value
 
         rsi = ta.momentum.RSIIndicator(data['close'], window=self.rsi_period).rsi()
-        
-        signals[rsi < self.oversold] = TradeAction.ENTER_LONG.value
-        signals[rsi > self.overbought] = TradeAction.ENTER_SHORT.value
+
+        position = TradeAction.EXIT.value
+        for i in range(1, len(data)):
+            long_entry = rsi.iloc[i] < self.oversold
+            short_entry = rsi.iloc[i] > self.overbought
+            long_exit = position == TradeAction.ENTER_LONG.value and rsi.iloc[i] > self.overbought
+            short_exit = position == TradeAction.ENTER_SHORT.value and rsi.iloc[i] < self.oversold
+
+            if position == TradeAction.EXIT.value:
+                if long_entry:
+                    position = TradeAction.ENTER_LONG.value
+                elif short_entry:
+                    position = TradeAction.ENTER_SHORT.value
+            elif long_exit or short_exit:
+                position = TradeAction.EXIT.value
+
+            signals.iloc[i] = position
 
         return signals

--- a/tests/test_strategy_signals.py
+++ b/tests/test_strategy_signals.py
@@ -18,6 +18,8 @@ spec.loader.exec_module(mac_module)
 MovingAverageCrossover = mac_module.MovingAverageCrossover
 from strategies.macd_rsi import MACD_RSIStrategy
 from strategies.macd_rsi_cmf import MACD_RSI_CMF_Strategy
+from strategies.bollinger_bands_strategy import BollingerBandsStrategy
+from strategies.rsi_strategy import RSIStrategy
 
 def test_moving_average_crossover_signals():
     dates = pd.date_range('2024-01-01', periods=5)
@@ -149,3 +151,39 @@ def test_vwap_window_influences_signals():
 
     assert list(signals_short) == expected_short
     assert list(signals_long) == expected_long
+
+
+def test_bollinger_bands_position_persistence():
+    dates = pd.date_range('2024-01-01', periods=5)
+    close = [1, 0, 0, 0, 0.1]
+    data = pd.DataFrame({
+        'close': close,
+        'open': close,
+        'high': close,
+        'low': close,
+        'volume': [1] * 5,
+    }, index=dates)
+
+    strat = BollingerBandsStrategy(window=2, num_std=0.5)
+    signals = strat.generate_signals(data)
+    expected = [TradeAction.EXIT.value, TradeAction.ENTER_LONG.value,
+                TradeAction.ENTER_LONG.value, TradeAction.ENTER_LONG.value,
+                TradeAction.EXIT.value]
+    assert list(signals) == expected
+
+
+def test_rsi_position_persistence():
+    dates = pd.date_range('2024-01-01', periods=5)
+    close = [10, 20, 30, 80, 90]
+    data = pd.DataFrame({
+        'close': close,
+        'open': close,
+        'high': close,
+        'low': close,
+        'volume': [1] * 5,
+    }, index=dates)
+
+    strat = RSIStrategy(rsi_period=2, oversold=30, overbought=70)
+    signals = strat.generate_signals(data)
+    expected = [TradeAction.EXIT.value] + [TradeAction.ENTER_SHORT.value] * 4
+    assert list(signals) == expected

--- a/utils/position_sizing.py
+++ b/utils/position_sizing.py
@@ -2,6 +2,8 @@ def risk_based_position_sizing(available_capital, risk_per_trade, entry_price, s
     """Calculate position size based on risk per trade."""
     risk_amount = available_capital * risk_per_trade
     stop_loss_distance = abs(entry_price - stop_loss_price)
+    if stop_loss_distance == 0:
+        return 0
     position_size = risk_amount / stop_loss_distance
     max_position_size = available_capital / entry_price
     return min(position_size, max_position_size)


### PR DESCRIPTION
## Summary
- implement persistent position logic for `BollingerBandsStrategy` and `RSIStrategy`
- guard against zero stop loss distance in position sizing utility
- add tests covering new signal persistence behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d513bd8483219af1b09f966979a3