### PR TITLE
Fix strategy constructors to initialize risk params

### DIFF
--- a/strategies/bollinger_bands_strategy.py
+++ b/strategies/bollinger_bands_strategy.py
@@ -4,7 +4,9 @@ from .base_strategy import Strategy
 from utils.enums import TradeAction
 
 class BollingerBandsStrategy(Strategy):
-    def __init__(self, window, num_std):
+    def __init__(self, window, num_std,
+                 stop_loss_pct=0, take_profit_pct=0):
+        super().__init__(stop_loss_pct, take_profit_pct)
         self.window = int(window)
         self.num_std = num_std
 

--- a/strategies/rsi_strategy.py
+++ b/strategies/rsi_strategy.py
@@ -4,7 +4,9 @@ from .base_strategy import Strategy
 from utils.enums import TradeAction
 
 class RSIStrategy(Strategy):
-    def __init__(self, rsi_period, oversold, overbought):
+    def __init__(self, rsi_period, oversold, overbought,
+                 stop_loss_pct=0, take_profit_pct=0):
+        super().__init__(stop_loss_pct, take_profit_pct)
         self.rsi_period = int(rsi_period)
         self.oversold = oversold
         self.overbought = overbought


### PR DESCRIPTION
## Summary
- initialize stop loss and take profit in `RSIStrategy`
- initialize stop loss and take profit in `BollingerBandsStrategy`

## Testing
- `pip install pandas==2.2.2 numpy==2.0.0 ta==0.11.0 scikit-learn==1.5.1 scikit-optimize==0.10.2 scipy==1.14.0 pytz==2024.1 websockets==12.0 deap==1.4.1 reportlab==4.2.2 pyswarm==0.6`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684adf264984832188b84d895ff19216