### PR TITLE
Implement PriceBreakoutVolumeStrategy

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,3 +35,19 @@ STRATEGY_PARAMS = {
 AVAILABLE_CAPITAL = 100  # Total capital in USD
 RISK_PER_TRADE = 0.10  # Risk per trade as a fraction of capital (e.g., 0.01 for 1%)
 
+# Default parameter ranges for the PriceBreakoutVolumeStrategy organised by timeframe
+PRICE_BREAKOUT_VOLUME_RANGES = {
+    '5m': [
+        {'name': 'lookback', 'type': 'int', 'low': 10, 'high': 50},
+        {'name': 'volume_multiplier', 'type': 'float', 'low': 1.0, 'high': 3.0},
+        {'name': 'stop_loss_pct', 'type': 'float', 'low': 1, 'high': 2},
+        {'name': 'take_profit_pct', 'type': 'float', 'low': 1, 'high': 4},
+    ],
+    '1h': [
+        {'name': 'lookback', 'type': 'int', 'low': 20, 'high': 100},
+        {'name': 'volume_multiplier', 'type': 'float', 'low': 1.0, 'high': 3.0},
+        {'name': 'stop_loss_pct', 'type': 'float', 'low': 1, 'high': 2},
+        {'name': 'take_profit_pct', 'type': 'float', 'low': 1, 'high': 6},
+    ],
+}
+

--- a/main.py
+++ b/main.py
@@ -4,7 +4,14 @@ from optimization import GeneticAlgorithmOptimizer, ParticleSwarmOptimizer, Baye
 from evaluation import ResultAnalyzer
 from reporting import ReportGenerator
 from trading_system_controller import TradingSystemController
-from strategies import VWAP_RSI_MACDStrategy, VWAP_RSI_ZeroLagMACDStrategy, ZeroLagMACD_OBV_Strategy, EMACrossover
+from strategies import (
+    VWAP_RSI_MACDStrategy,
+    VWAP_RSI_ZeroLagMACDStrategy,
+    ZeroLagMACD_OBV_Strategy,
+    EMACrossover,
+    PriceBreakoutVolumeStrategy,
+)
+from config import PRICE_BREAKOUT_VOLUME_RANGES
 from binance.client import Client
 from utils.enums import TradeMode
 
@@ -28,9 +35,12 @@ def main():
     # Set multiple objectives
     controller.set_objectives(['total_return'])
     
+    interval = Client.KLINE_INTERVAL_4HOUR
+    timeframe = interval
+
     best_results = controller.run(
         symbol='BTCUSDT',
-        interval=Client.KLINE_INTERVAL_4HOUR,
+        interval=interval,
         start_time="1 Mar, 2024",
         end_time="6 Jun, 2025",
         strategies=[ZeroLagMACD_OBV_Strategy],
@@ -114,7 +124,11 @@ def main():
                 {'name': 'fractal_bars', 'type': 'int', 'low': 3, 'high': 5},
                 {'name': 'stop_loss_pct', 'type': 'int', 'low': 1, 'high': 2},
                 {'name': 'take_profit_pct', 'type': 'int', 'low': 1, 'high': 4}
-            ]
+            ],
+            'PriceBreakoutVolumeStrategy': PRICE_BREAKOUT_VOLUME_RANGES.get(
+                timeframe,
+                PRICE_BREAKOUT_VOLUME_RANGES['1h'],
+            ),
         },
         n_iterations=100
     )

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -9,3 +9,4 @@ from .vwap_rsi_macd import VWAP_RSI_MACDStrategy
 from .william_fractals import WilliamsFractals
 from .vwap_rsi_nolagmacd import VWAP_RSI_ZeroLagMACDStrategy
 from .obv_nolagmacd import ZeroLagMACD_OBV_Strategy
+from .price_breakout_volume import PriceBreakoutVolumeStrategy

--- a/strategies/price_breakout_volume.py
+++ b/strategies/price_breakout_volume.py
@@ -1,0 +1,46 @@
+import pandas as pd
+from .base_strategy import Strategy
+from utils.enums import TradeAction
+
+
+class PriceBreakoutVolumeStrategy(Strategy):
+    """Simple breakout strategy that also requires a volume expansion."""
+
+    def __init__(self, lookback, volume_multiplier, stop_loss_pct, take_profit_pct):
+        super().__init__(stop_loss_pct, take_profit_pct)
+        self.lookback = max(1, int(lookback))
+        self.volume_multiplier = float(volume_multiplier)
+
+    def generate_signals(self, data: pd.DataFrame) -> pd.Series:
+        signals = pd.Series(index=data.index, dtype=int)
+        signals[:] = TradeAction.EXIT.value
+
+        highs = data['high'].shift(1).rolling(self.lookback).max()
+        lows = data['low'].shift(1).rolling(self.lookback).min()
+        avg_volume = data['volume'].shift(1).rolling(self.lookback).mean()
+
+        position = TradeAction.EXIT.value
+        for i in range(len(data)):
+            long_entry = (
+                data['close'].iloc[i] > highs.iloc[i]
+                and data['volume'].iloc[i] > avg_volume.iloc[i] * self.volume_multiplier
+            )
+            short_entry = (
+                data['close'].iloc[i] < lows.iloc[i]
+                and data['volume'].iloc[i] > avg_volume.iloc[i] * self.volume_multiplier
+            )
+
+            long_exit = position == TradeAction.ENTER_LONG.value and short_entry
+            short_exit = position == TradeAction.ENTER_SHORT.value and long_entry
+
+            if position == TradeAction.EXIT.value:
+                if long_entry:
+                    position = TradeAction.ENTER_LONG.value
+                elif short_entry:
+                    position = TradeAction.ENTER_SHORT.value
+            elif long_exit or short_exit:
+                position = TradeAction.EXIT.value
+
+            signals.iloc[i] = position
+
+        return signals

--- a/tests/test_strategy_signals.py
+++ b/tests/test_strategy_signals.py
@@ -20,6 +20,7 @@ from strategies.macd_rsi import MACD_RSIStrategy
 from strategies.macd_rsi_cmf import MACD_RSI_CMF_Strategy
 from strategies.bollinger_bands_strategy import BollingerBandsStrategy
 from strategies.rsi_strategy import RSIStrategy
+from strategies.price_breakout_volume import PriceBreakoutVolumeStrategy
 
 def test_moving_average_crossover_signals():
     dates = pd.date_range('2024-01-01', periods=5)
@@ -186,4 +187,32 @@ def test_rsi_position_persistence():
     strat = RSIStrategy(rsi_period=2, oversold=30, overbought=70)
     signals = strat.generate_signals(data)
     expected = [TradeAction.EXIT.value] + [TradeAction.ENTER_SHORT.value] * 4
+    assert list(signals) == expected
+
+
+def test_price_breakout_volume_signals():
+    dates = pd.date_range('2024-01-01', periods=5)
+    close = [5, 4, 6, 3, 2]
+    data = pd.DataFrame({
+        'close': close,
+        'open': close,
+        'high': close,
+        'low': close,
+        'volume': [1, 1, 5, 5, 8],
+    }, index=dates)
+
+    strat = PriceBreakoutVolumeStrategy(
+        lookback=2,
+        volume_multiplier=1.5,
+        stop_loss_pct=1,
+        take_profit_pct=1,
+    )
+    signals = strat.generate_signals(data)
+    expected = [
+        TradeAction.EXIT.value,
+        TradeAction.EXIT.value,
+        TradeAction.ENTER_LONG.value,
+        TradeAction.EXIT.value,
+        TradeAction.ENTER_SHORT.value,
+    ]
     assert list(signals) == expected


### PR DESCRIPTION
## Summary
- implement `PriceBreakoutVolumeStrategy`
- expose strategy from `strategies.__init__`
- define `PRICE_BREAKOUT_VOLUME_RANGES` in config
- make `main.py` load parameter ranges based on timeframe
- test signal generation of PriceBreakoutVolumeStrategy

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684afc9196b483218223ba5f8535ff7c