### PR TITLE
Add configurable signal-based exits

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@ The optimiser ships with multiple algorithms and can run them in isolation or as
 - **Objective weighting** – optimise for one or several metrics (total return, win rate, Sharpe ratio, etc.) with optional weights.
 - **Risk based position sizing** – trades use a fixed risk percentage of the available capital.
 - **Long/short modes** – strategies can run in long only, short only or both directions.
+- **Configurable exits** – allow trades to close on stop-loss/take-profit only, signal based exits or both.
 - **Detailed PDF reports** – parameter table, train/test performance metrics and a list of all trades.
 - **Telegram notifications** – `trades_finder.py` can scan the latest data and push alerts when new entry signals appear.
 

--- a/strategy_manager.py
+++ b/strategy_manager.py
@@ -35,7 +35,7 @@ class Trade:
 
 class StrategyManager:
     def __init__(self, data, initial_capital=100000, risk_per_trade=0.02,
-                 trade_mode=TradeMode.BOTH):
+                 trade_mode=TradeMode.BOTH, signal_exit: bool = True):
         self.data = data
         self.current_position = Position.NEUTRAL
         self.trades = []
@@ -43,12 +43,13 @@ class StrategyManager:
         self.available_capital = initial_capital
         self.risk_per_trade = risk_per_trade
         self.trade_mode = trade_mode
+        self.signal_exit = signal_exit
         # When running live we might not yet have the next candle available
         # when a signal is generated.  ``pending_entry`` stores the details of
         # such trade so it can be opened once the next candle appears.
         self.pending_entry = None
 
-    def reset(self, data, trade_mode=None):
+    def reset(self, data, trade_mode=None, signal_exit=None):
         self.data = data
         self.current_position = Position.NEUTRAL
         self.trades = []
@@ -56,6 +57,8 @@ class StrategyManager:
         self.pending_entry = None
         if trade_mode is not None:
             self.trade_mode = trade_mode
+        if signal_exit is not None:
+            self.signal_exit = signal_exit
 
     def execute_strategy(self, strategy):
         signals = strategy.generate_signals(self.data)
@@ -81,7 +84,11 @@ class StrategyManager:
             elif signal == TradeAction.ENTER_SHORT and self.current_position != Position.SHORT:
                 if self.trade_mode in (TradeMode.BOTH, TradeMode.SHORT_ONLY):
                     self.enter_trade(timestamp, Position.SHORT, strategy.stop_loss_pct, strategy.take_profit_pct)
-            elif signal == TradeAction.EXIT and self.current_position != Position.NEUTRAL:
+            elif (
+                signal == TradeAction.EXIT
+                and self.current_position != Position.NEUTRAL
+                and self.signal_exit
+            ):
                 self.exit_trade(timestamp)
 
     def execute_signals(self, signals, strategy):
@@ -112,7 +119,11 @@ class StrategyManager:
             elif signal == TradeAction.ENTER_SHORT and self.current_position != Position.SHORT:
                 if self.trade_mode in (TradeMode.BOTH, TradeMode.SHORT_ONLY):
                     self.enter_trade(timestamp, Position.SHORT, strategy.stop_loss_pct, strategy.take_profit_pct)
-            elif signal == TradeAction.EXIT and self.current_position != Position.NEUTRAL:
+            elif (
+                signal == TradeAction.EXIT
+                and self.current_position != Position.NEUTRAL
+                and self.signal_exit
+            ):
                 self.exit_trade(timestamp)
 
     def enter_trade(self, timestamp, position, stop_loss_pct, take_profit_pct):

--- a/tests/test_strategy_manager.py
+++ b/tests/test_strategy_manager.py
@@ -37,6 +37,20 @@ def make_data():
     }, index=index)
 
 
+def make_data_no_exit():
+    index = [datetime(2024, 1, 1), datetime(2024, 1, 2)]
+    return pd.DataFrame(
+        {
+            "open": [100, 110],
+            "high": [105, 111],
+            "low": [95, 105],
+            "close": [100, 110],
+            "volume": [1000, 1000],
+        },
+        index=index,
+    )
+
+
 def test_risk_based_position_sizing():
     sm = StrategyManager(None, initial_capital=1000, risk_per_trade=0.1)
     size = sm.risk_based_position_sizing(100, 90)
@@ -77,3 +91,14 @@ def test_trade_mode_short_only():
     sm.execute_strategy(LongShortStrategy())
     assert len(sm.trades) == 1
     assert sm.trades[0].position == Position.SHORT
+
+
+def test_disable_signal_exit():
+    data = make_data_no_exit()
+    sm = StrategyManager(data, initial_capital=100, risk_per_trade=0.1, signal_exit=False)
+    sm.execute_strategy(DummyStrategy())
+    # Trade should remain open because exit signals are ignored
+    assert len(sm.trades) == 1
+    trade = sm.trades[0]
+    assert trade.exit_time is None
+    assert sm.current_position == Position.LONG

--- a/tests/test_strategy_signals.py
+++ b/tests/test_strategy_signals.py
@@ -237,6 +237,7 @@ def test_hyper_scalper_signals():
         ema_long=4,
         adx_window=1,
         adx_threshold=-1,
+        pullback_window=1,
         stop_loss_pct=1,
         take_profit_pct=1,
     )


### PR DESCRIPTION
## Summary
- allow toggling of signal-based exits in `StrategyManager`
- document new capability in README
- update tests and add coverage for disabling exit signals
- fix `HyperScalper` test to supply required argument

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1962f4f08321a5637215736e33cd