### PR TITLE
Add parameter step support

### DIFF
--- a/optimization/bayesian_optimization.py
+++ b/optimization/bayesian_optimization.py
@@ -3,12 +3,13 @@ from skopt.utils import use_named_args
 from skopt.space import Real, Integer
 from .optimizer import Optimizer
 import numpy as np
+from .utils import clamp_value
 
 class BayesianOptimizer(Optimizer):
     def optimize(self, objective_function, param_ranges, n_iterations, initial_point=None):
         def bounded_objective(x):
             try:
-                params = [int(val) if param['type'] == 'int' else val for val, param in zip(x, param_ranges)]
+                params = [clamp_value(val, spec) for val, spec in zip(x, param_ranges)]
                 result = -objective_function(params)  # sklearn minimizes, so we negate
                 if np.isinf(result) or np.isnan(result):
                     return 1e10  # Return a large finite number instead of infinity
@@ -42,4 +43,5 @@ class BayesianOptimizer(Optimizer):
             acq_func='EI',  # Expected Improvement
         )
         
-        return [int(val) if param['type'] == 'int' else val for val, param in zip(result.x, param_ranges)]
+        return [clamp_value(val, spec) for val, spec in zip(result.x, param_ranges)]
+

--- a/optimization/differential_evolution.py
+++ b/optimization/differential_evolution.py
@@ -1,13 +1,14 @@
 from scipy.optimize import differential_evolution
 from .optimizer import Optimizer
 import numpy as np
+from .utils import clamp_value
 
 class DifferentialEvolutionOptimizer(Optimizer):
     def optimize(self, objective_function, param_ranges, n_iterations, initial_guess=None):
         bounds = [(param['low'], param['high']) for param in param_ranges]
 
         def wrapper(x):
-            params = [int(val) if param['type'] == 'int' else val for val, param in zip(x, param_ranges)]
+            params = [clamp_value(val, spec) for val, spec in zip(x, param_ranges)]
             return objective_function(params)
 
         kwargs = {'maxiter': n_iterations, 'strategy': 'best1bin'}
@@ -19,4 +20,4 @@ class DifferentialEvolutionOptimizer(Optimizer):
 
         result = differential_evolution(wrapper, bounds, **kwargs)
 
-        return [int(val) if param['type'] == 'int' else val for val, param in zip(result.x, param_ranges)]
+        return [clamp_value(val, spec) for val, spec in zip(result.x, param_ranges)]

--- a/optimization/genetic_algorithm.py
+++ b/optimization/genetic_algorithm.py
@@ -1,6 +1,7 @@
 import numpy as np
 from deap import base, creator, tools, algorithms
 from .optimizer import Optimizer
+from .utils import clamp_value, sample_value
 
 # Ensure classes are created only once
 if not hasattr(creator, "FitnessMax"):
@@ -12,17 +13,14 @@ class GeneticAlgorithmOptimizer(Optimizer):
     def optimize(self, objective_function, param_ranges, n_iterations):
         toolbox = base.Toolbox()
         for i, param in enumerate(param_ranges):
-            if param['type'] == 'int':
-                toolbox.register(f"attr_{i}", np.random.randint, param['low'], param['high'] + 1)
-            else:
-                toolbox.register(f"attr_{i}", np.random.uniform, param['low'], param['high'])
+            toolbox.register(f"attr_{i}", sample_value, param)
 
         toolbox.register("individual", tools.initCycle, creator.Individual,
                          [getattr(toolbox, f"attr_{i}") for i in range(len(param_ranges))], n=1)
         toolbox.register("population", tools.initRepeat, list, toolbox.individual)
 
         def evaluate(individual):
-            params = [int(val) if param['type'] == 'int' else val for val, param in zip(individual, param_ranges)]
+            params = [clamp_value(val, param) for val, param in zip(individual, param_ranges)]
             result = objective_function(params)
             return (result,)
 
@@ -31,11 +29,7 @@ class GeneticAlgorithmOptimizer(Optimizer):
         def mutate_and_bound(individual):
             tools.mutGaussian(individual, mu=0, sigma=1, indpb=0.2)
             for i, param in enumerate(param_ranges):
-                low, high = param['low'], param['high']
-                if param['type'] == 'int':
-                    individual[i] = int(round(min(max(individual[i], low), high)))
-                else:
-                    individual[i] = min(max(individual[i], low), high)
+                individual[i] = clamp_value(individual[i], param)
             return (individual,)
 
         toolbox.register("mutate", mutate_and_bound)
@@ -45,4 +39,4 @@ class GeneticAlgorithmOptimizer(Optimizer):
         result, _ = algorithms.eaSimple(population, toolbox, cxpb=0.7, mutpb=0.2, ngen=n_iterations, verbose=False)
 
         best_individual = tools.selBest(result, k=1)[0]
-        return [int(val) if param['type'] == 'int' else val for val, param in zip(best_individual, param_ranges)]
+        return [clamp_value(val, param) for val, param in zip(best_individual, param_ranges)]

--- a/optimization/hybrid_optimizer.py
+++ b/optimization/hybrid_optimizer.py
@@ -1,19 +1,11 @@
 import multiprocessing as mp
 from .optimizer import Optimizer
+from .utils import clamp_value
 
 
 def clamp_params(params, param_ranges):
     """Clamp parameter values to their declared ranges and cast types."""
-    clamped = []
-    for val, spec in zip(params, param_ranges):
-        low, high = spec['low'], spec['high']
-        if spec['type'] == 'int':
-            val = int(round(val))
-        else:
-            val = float(val)
-        val = min(max(val, low), high)
-        clamped.append(val)
-    return clamped
+    return [clamp_value(val, spec) for val, spec in zip(params, param_ranges)]
 
 class ParallelHybridOptimizer(Optimizer):
     def __init__(self, ga_optimizer, pso_optimizer, bayesian_optimizer, differential_optimizer, n_processes=None):

--- a/optimization/particle_swarm.py
+++ b/optimization/particle_swarm.py
@@ -1,5 +1,6 @@
 from pyswarm import pso
 from .optimizer import Optimizer
+from .utils import clamp_value
 
 class ParticleSwarmOptimizer(Optimizer):
     def optimize(self, objective_function, param_ranges, n_iterations, initial_guess=None):
@@ -7,13 +8,12 @@ class ParticleSwarmOptimizer(Optimizer):
         ub = [p['high'] for p in param_ranges]
 
         def pso_objective(x):
-            return -objective_function(
-                [int(val) if param['type'] == 'int' else val for val, param in zip(x, param_ranges)]
-            )  # PSO minimizes, so negate
+            params = [clamp_value(val, spec) for val, spec in zip(x, param_ranges)]
+            return -objective_function(params)  # PSO minimizes, so negate
 
         # NOTE: pyswarm's `pso` does not support setting an initial population.
         #       For now we simply ignore `initial_guess` if provided.
         xopt, _ = pso(pso_objective, lb, ub, swarmsize=10, maxiter=n_iterations, debug=False)
 
         print("XOPT result\n", xopt)
-        return [int(val) if param['type'] == 'int' else val for val, param in zip(xopt, param_ranges)]
+        return [clamp_value(val, spec) for val, spec in zip(xopt, param_ranges)]

--- a/optimization/utils.py
+++ b/optimization/utils.py
@@ -1,0 +1,33 @@
+import random
+
+
+def clamp_value(val, spec):
+    """Clamp *val* to the range specified in *spec* and apply any step."""
+    low, high = spec['low'], spec['high']
+    step = spec.get('step')
+    if step is not None:
+        val = low + round((val - low) / step) * step
+    if spec['type'] == 'int':
+        val = int(round(val))
+    else:
+        val = float(val)
+    val = min(max(val, low), high)
+    if step is not None:
+        # Ensure clamped value respects step boundaries after rounding
+        val = low + round((val - low) / step) * step
+        if spec['type'] == 'int':
+            val = int(round(val))
+    return val
+
+
+def sample_value(spec):
+    """Return a random value respecting type, range and step."""
+    low, high = spec['low'], spec['high']
+    step = spec.get('step')
+    if step is not None:
+        count = int(round((high - low) / step))
+        values = [low + i * step for i in range(count + 1)]
+        return random.choice(values)
+    if spec['type'] == 'int':
+        return random.randint(low, high)
+    return random.uniform(low, high)

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ All configuration lives in `main.py`. The important steps are:
 controller.set_objectives({'total_return': 70, 'sharpe_ratio': 30})
 ```
 
-2. **Specify strategies and parameter ranges.** Each entry in `param_ranges` describes a tunable parameter with `low`, `high` and `type` (`int` or `float`).
+2. **Specify strategies and parameter ranges.** Each entry in `param_ranges` describes a tunable parameter with `low`, `high`, `type` (`int` or `float`) and an optional `step` value to control the search granularity.
 3. **Select the optimisers** you wish to use – GA, PSO, Differential Evolution, Bayesian, or the `ParallelHybridOptimizer` which chains them together.
 4. **Run `main.py`** to start the optimisation.
 

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -57,3 +57,12 @@ def test_parallel_hybrid_optimizer():
     result = pho.optimize(quadratic_objective, param_ranges, n_iterations=8)
     assert abs(result[0] - 3) < 1.5
     assert param_ranges[0]['low'] <= result[0] <= param_ranges[0]['high']
+
+
+def test_parameter_step_handling():
+    np.random.seed(0)
+    ga = GeneticAlgorithmOptimizer()
+    step_ranges = [{'low': 0, 'high': 6, 'type': 'int', 'step': 2}]
+    result = ga.optimize(lambda p: -(p[0] - 4) ** 2, step_ranges, n_iterations=4)
+    assert (result[0] - step_ranges[0]['low']) % 2 == 0
+


### PR DESCRIPTION
## Summary
- add `clamp_value`/`sample_value` helpers to honor optional `step`
- integrate step handling across all optimizers
- document `step` key in the README
- test that optimizers respect the `step` field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1ef34e988321ae66e50e094b1dc2