### PR TITLE
Validate positive step in optimizer utils

### DIFF
--- a/optimization/utils.py
+++ b/optimization/utils.py
@@ -6,6 +6,8 @@ def clamp_value(val, spec):
     low, high = spec['low'], spec['high']
     step = spec.get('step')
     if step is not None:
+        if step <= 0:
+            raise ValueError("spec['step'] must be positive")
         val = low + round((val - low) / step) * step
     if spec['type'] == 'int':
         val = int(round(val))
@@ -25,6 +27,8 @@ def sample_value(spec):
     low, high = spec['low'], spec['high']
     step = spec.get('step')
     if step is not None:
+        if step <= 0:
+            raise ValueError("spec['step'] must be positive")
         count = int(round((high - low) / step))
         values = [low + i * step for i in range(count + 1)]
         return random.choice(values)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,28 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import pytest
+from optimization.utils import clamp_value, sample_value
+
+
+def test_clamp_value_invalid_step_zero():
+    spec = {'low': 0, 'high': 10, 'type': 'int', 'step': 0}
+    with pytest.raises(ValueError):
+        clamp_value(5, spec)
+
+
+def test_clamp_value_invalid_step_negative():
+    spec = {'low': 0, 'high': 10, 'type': 'int', 'step': -1}
+    with pytest.raises(ValueError):
+        clamp_value(5, spec)
+
+
+def test_sample_value_invalid_step_zero():
+    spec = {'low': 0, 'high': 10, 'type': 'int', 'step': 0}
+    with pytest.raises(ValueError):
+        sample_value(spec)
+
+
+def test_sample_value_invalid_step_negative():
+    spec = {'low': 0, 'high': 10, 'type': 'int', 'step': -1}
+    with pytest.raises(ValueError):
+        sample_value(spec)


### PR DESCRIPTION
## Summary
- validate that `spec['step']` is positive in `clamp_value` and `sample_value`
- add regression tests for invalid step handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b94afe3bc8321a9a941b960a7f3ff