### PR TITLE
Add trade cost and slippage support

### DIFF
--- a/evaluation/result_analyzer.py
+++ b/evaluation/result_analyzer.py
@@ -64,6 +64,7 @@ class ResultAnalyzer:
                 'profitable_trades': 0,
                 'win_rate': 0,
                 'total_return': 0,
+                'total_costs': 0,
                 'sharpe_ratio': -np.inf,
                 'sortino_ratio': -np.inf,
                 'max_drawdown': 0,
@@ -76,12 +77,14 @@ class ResultAnalyzer:
 
         returns = [trade.profit_loss for trade in trades if trade.profit_loss is not None]
         total_return = sum(returns)
-        
+        total_costs = sum(getattr(trade, "costs", 0) for trade in trades)
+
         performance = {
             'total_trades': total_trades,
             'profitable_trades': profitable_trades,
             'win_rate': round(win_rate, 3),
             'total_return': round(total_return, 2),
+            'total_costs': round(total_costs, 2),
             'sharpe_ratio': round(self.calculate_sharpe_ratio(trades),3),
             'sortino_ratio': round(self.calculate_sortino_ratio(trades),3),
             'max_drawdown': round(self.calculate_max_drawdown(trades),3),

--- a/strategy_manager.py
+++ b/strategy_manager.py
@@ -2,7 +2,18 @@ from utils.enums import Position, TradeAction, TradeMode
 from utils.position_sizing import risk_based_position_sizing as util_risk_based_position_sizing
 
 class Trade:
-    def __init__(self, entry_time, entry_price, position, stop_loss, take_profit, size):
+    def __init__(
+        self,
+        entry_time,
+        entry_price,
+        position,
+        stop_loss,
+        take_profit,
+        size,
+        buy_fee=0.0,
+        sell_fee=0.0,
+        slippage=0.0,
+    ):
         self.entry_time = entry_time
         self.entry_price = entry_price
         self.position = position
@@ -12,12 +23,21 @@ class Trade:
         self.take_profit = take_profit
         self.size = size
         self.remaining_capital = None
+        self.buy_fee = buy_fee
+        self.sell_fee = sell_fee
+        self.slippage = slippage
+        self.costs = 0.0
 
     @property
     def profit_loss(self):
         if self.exit_price is None:
             return None
-        return (self.exit_price - self.entry_price) * self.position.value * self.size
+        return (
+            (self.exit_price - self.entry_price)
+            * self.position.value
+            * self.size
+            - self.costs
+        )
     
     def get_data(self) -> dict:
         return {
@@ -27,6 +47,7 @@ class Trade:
             "exit_time": str(self.exit_time),
             "exit_price": self.exit_price,
             "profit_loss": self.profit_loss,
+            "costs": self.costs,
             "stop_loss": self.stop_loss,
             "take_profit": self.take_profit,
             "size": self.size,
@@ -34,8 +55,17 @@ class Trade:
         }
 
 class StrategyManager:
-    def __init__(self, data, initial_capital=100000, risk_per_trade=0.02,
-                 trade_mode=TradeMode.BOTH, signal_exit: bool = True):
+    def __init__(
+        self,
+        data,
+        initial_capital=100000,
+        risk_per_trade=0.02,
+        trade_mode=TradeMode.BOTH,
+        signal_exit: bool = True,
+        buy_fee: float = 0.0,
+        sell_fee: float = 0.0,
+        slippage: float = 0.0,
+    ):
         self.data = data
         self.current_position = Position.NEUTRAL
         self.trades = []
@@ -44,6 +74,9 @@ class StrategyManager:
         self.risk_per_trade = risk_per_trade
         self.trade_mode = trade_mode
         self.signal_exit = signal_exit
+        self.buy_fee = buy_fee
+        self.sell_fee = sell_fee
+        self.slippage = slippage
         # When running live we might not yet have the next candle available
         # when a signal is generated.  ``pending_entry`` stores the details of
         # such trade so it can be opened once the next candle appears.
@@ -181,7 +214,13 @@ class StrategyManager:
                 
         current_trade.exit_time = timestamp
         current_trade.exit_price = exit_price
-        
+
+        current_trade.costs = (
+            self.buy_fee * current_trade.entry_price * current_trade.size
+            + self.sell_fee * exit_price * current_trade.size
+            + self.slippage * (current_trade.entry_price + exit_price) * current_trade.size
+        )
+
         self.available_capital += current_trade.profit_loss
         current_trade.remaining_capital = self.available_capital
         
@@ -209,6 +248,11 @@ class StrategyManager:
         if exit_price is not None:
             current_trade.exit_time = timestamp
             current_trade.exit_price = exit_price
+            current_trade.costs = (
+                self.buy_fee * current_trade.entry_price * current_trade.size
+                + self.sell_fee * exit_price * current_trade.size
+                + self.slippage * (current_trade.entry_price + exit_price) * current_trade.size
+            )
             self.available_capital += current_trade.profit_loss
             current_trade.remaining_capital = self.available_capital
             self.current_position = Position.NEUTRAL
@@ -232,7 +276,19 @@ class StrategyManager:
             take_profit = entry_price * (1 - take_profit_pct)
 
         size = self.risk_based_position_sizing(entry_price, stop_loss)
-        self.trades.append(Trade(entry_time, entry_price, position, stop_loss, take_profit, size))
+        self.trades.append(
+            Trade(
+                entry_time,
+                entry_price,
+                position,
+                stop_loss,
+                take_profit,
+                size,
+                buy_fee=self.buy_fee,
+                sell_fee=self.sell_fee,
+                slippage=self.slippage,
+            )
+        )
 
     def process_pending_entry(self, timestamp, open_price):
         """Execute any trade that was waiting for the next candle."""

--- a/tests/test_report_generation.py
+++ b/tests/test_report_generation.py
@@ -26,6 +26,7 @@ def test_report_generation(tmp_path):
                     'exit_time': '2024-01-02 00:00:00',
                     'exit_price': 110,
                     'profit_loss': 10,
+                    'costs': 0,
                     'size': 1,
                     'remaining_capital': 110
                 }

--- a/tests/test_strategy_manager.py
+++ b/tests/test_strategy_manager.py
@@ -2,6 +2,7 @@ import os, sys
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from datetime import datetime
 import pandas as pd
+import pytest
 from strategy_manager import StrategyManager
 from utils.enums import TradeAction, TradeMode, Position
 
@@ -74,6 +75,22 @@ def test_execute_strategy_basic():
     assert trade.entry_time == data.index[1]
     assert trade.exit_time == data.index[1]
     assert trade.profit_loss == -10
+
+
+def test_trade_costs_applied():
+    data = make_data()
+    sm = StrategyManager(
+        data,
+        initial_capital=100,
+        risk_per_trade=0.1,
+        buy_fee=0.01,
+        sell_fee=0.01,
+        slippage=0.01,
+    )
+    sm.execute_strategy(DummyStrategy())
+    trade = sm.trades[0]
+    assert trade.costs == pytest.approx(3.8, rel=1e-3)
+    assert trade.profit_loss == pytest.approx(-13.8, rel=1e-3)
 
 
 def test_trade_mode_long_only():

--- a/tests/test_trade_analyzer.py
+++ b/tests/test_trade_analyzer.py
@@ -20,6 +20,24 @@ def test_profit_loss_short():
     t = make_trade(100, 90, Position.SHORT)
     assert t.profit_loss == 10
 
+
+def test_profit_loss_with_costs():
+    t = Trade(
+        datetime(2024, 1, 1),
+        100,
+        Position.LONG,
+        0,
+        0,
+        1,
+        buy_fee=0.01,
+        sell_fee=0.01,
+        slippage=0.01,
+    )
+    t.exit_time = datetime(2024, 1, 2)
+    t.exit_price = 110
+    t.costs = 100 * 0.01 + 110 * 0.01 + (100 + 110) * 0.01
+    assert t.profit_loss == pytest.approx(110 - 100 - t.costs, rel=1e-9)
+
 def test_result_analyzer():
     trades = [
         make_trade(100, 110, Position.LONG),
@@ -32,6 +50,7 @@ def test_result_analyzer():
     assert perf['profitable_trades'] == 2
     assert perf['win_rate'] == pytest.approx(0.667, rel=1e-3)
     assert perf['total_return'] == pytest.approx(15.0, rel=1e-3)
+    assert perf['total_costs'] == 0
     assert perf['sharpe_ratio'] == pytest.approx(13.509, rel=1e-3)
     assert perf['sortino_ratio'] == 0
     assert perf['max_drawdown'] == 0.25


### PR DESCRIPTION
## Summary
- extend `StrategyManager` with buy/sell fees and slippage handling
- record trade costs and update profit/loss computations
- expose costs in `Trade.get_data`
- report total trade costs via `ResultAnalyzer`
- test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ba75d48688321b351d262d7479a97