### PR TITLE
Improve float parameter rounding

### DIFF
--- a/optimization/utils.py
+++ b/optimization/utils.py
@@ -19,6 +19,10 @@ def clamp_value(val, spec):
         val = low + round((val - low) / step) * step
         if spec['type'] == 'int':
             val = int(round(val))
+    if spec['type'] == 'float':
+        decimals = spec.get('decimals', 2)
+        val = round(val, decimals)
+        val = min(max(val, low), high)
     return val
 
 
@@ -31,7 +35,9 @@ def sample_value(spec):
             raise ValueError("spec['step'] must be positive")
         count = int(round((high - low) / step))
         values = [low + i * step for i in range(count + 1)]
-        return random.choice(values)
-    if spec['type'] == 'int':
-        return random.randint(low, high)
-    return random.uniform(low, high)
+        val = random.choice(values)
+    elif spec['type'] == 'int':
+        val = random.randint(low, high)
+    else:
+        val = random.uniform(low, high)
+    return clamp_value(val, spec)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,3 +26,13 @@ def test_sample_value_invalid_step_negative():
     spec = {'low': 0, 'high': 10, 'type': 'int', 'step': -1}
     with pytest.raises(ValueError):
         sample_value(spec)
+
+
+def test_float_rounding_in_clamp_and_sample():
+    spec = {'low': 0.0, 'high': 1.0, 'type': 'float'}
+    val = clamp_value(0.123456, spec)
+    assert val == 0.12
+
+    for _ in range(5):
+        sv = sample_value(spec)
+        assert abs(sv - round(sv, 2)) < 1e-9


### PR DESCRIPTION
## Summary
- round float parameters to two decimals in clamp and sampling
- test float rounding behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd923902083219da5456a60aa89d4