### PR TITLE
Add strategy tester utility

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -121,6 +121,19 @@ Once added you can optimise it like the provided examples.
 - `trades_finder.py` – scans recent candles for a given strategy and sends Telegram messages if a new entry signal is detected.
 - `tests/` – a suite of unit tests covering the optimisers, strategies and reporting utilities. Run them with `pytest` to verify changes.
 
+## Strategy tester
+
+`strategy_tester.py` runs a single strategy with explicit parameter values and
+produces a PDF report. Provide the strategy name, a JSON file containing the
+parameters and the data range:
+
+```bash
+python strategy_tester.py --strategy HyperScalper --params params.json --symbol BTCUSDT --interval 1d --start 2020-01-01 --end 2024-01-01
+```
+
+The report will be saved under `reports/` using the same layout as the
+optimisation output.
+
 ## Project structure
 
 ```bash
@@ -133,6 +146,7 @@ Once added you can optimise it like the provided examples.
 ├── tests/                    # Unit tests
 ├── utils/                    # Enums and helpers
 ├── main.py                   # Entry point for optimisation
+├── strategy_tester.py        # Run a single strategy backtest
 ├── optimization/             # Optimisation algorithms
 ├── strategy_manager.py       # Trade management engine
 ├── trading_system_controller.py # High level orchestration

--- a/strategy_tester.py
+++ b/strategy_tester.py
@@ -1,0 +1,98 @@
+import argparse
+import json
+from datetime import datetime
+
+from data import DataLoader
+from strategy_manager import StrategyManager
+from evaluation import ResultAnalyzer
+from reporting import ReportGenerator
+from utils.enums import TradeMode
+import strategies
+import config
+
+
+class StrategyTester:
+    def __init__(self, data_loader, strategy_manager, result_analyzer, report_generator):
+        self.data_loader = data_loader
+        self.strategy_manager = strategy_manager
+        self.result_analyzer = result_analyzer
+        self.report_generator = report_generator
+
+    @classmethod
+    def from_config(cls):
+        loader = DataLoader(config.BINANCE_API_KEY, config.BINANCE_API_SECRET)
+        manager = StrategyManager(
+            None,
+            initial_capital=100,
+            risk_per_trade=0.10,
+            trade_mode=TradeMode.LONG_ONLY,
+            signal_exit=False,
+            buy_fee=0.001,
+            sell_fee=0.001,
+        )
+        return cls(loader, manager, ResultAnalyzer(), ReportGenerator())
+
+    def run(self, strategy_class, params, symbol, interval, start_time, end_time, report_file=None):
+        data = self.data_loader.fetch_historical_data(symbol, interval, start_time, end_time)
+        self.strategy_manager.reset(data)
+        strategy = strategy_class(**params)
+        self.strategy_manager.execute_strategy(strategy)
+        performance = self.result_analyzer.analyze(self.strategy_manager.trades, interval)
+        trades = [t.get_data() for t in self.strategy_manager.trades]
+
+        results = {
+            strategy_class.__name__: {
+                "params": params,
+                "performance": performance,
+                "trades": trades,
+            }
+        }
+
+        self.report_generator.generate_report(
+            results,
+            filename=report_file,
+            symbol=symbol,
+            interval=interval,
+            start_time=start_time,
+            end_time=end_time,
+        )
+        return results
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Run a single strategy backtest")
+    parser.add_argument("--strategy", required=True, help="Strategy class name")
+    parser.add_argument("--params", required=True, help="JSON file with parameter values")
+    parser.add_argument("--symbol", required=True, help="Trading pair symbol")
+    parser.add_argument("--interval", required=True, help="Candle interval, e.g. 1d")
+    parser.add_argument("--start", required=True, help="Start date YYYY-MM-DD")
+    parser.add_argument("--end", required=True, help="End date YYYY-MM-DD")
+    parser.add_argument("--report", default=None, help="Output PDF file")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    with open(args.params) as f:
+        params = json.load(f)
+
+    strategy_cls = getattr(strategies, args.strategy)
+
+    # Binance expects dates like "1 Jan, 2020"
+    def fmt(date_str):
+        return datetime.strptime(date_str, "%Y-%m-%d").strftime("%d %b, %Y")
+
+    tester = StrategyTester.from_config()
+    tester.run(
+        strategy_cls,
+        params,
+        args.symbol,
+        args.interval,
+        fmt(args.start),
+        fmt(args.end),
+        report_file=args.report,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_strategy_tester.py
+++ b/tests/test_strategy_tester.py
@@ -1,0 +1,70 @@
+import os
+import pandas as pd
+from strategy_manager import StrategyManager
+from evaluation import ResultAnalyzer
+from utils.enums import TradeAction, TradeMode
+from reporting.report_generator import ReportGenerator
+from strategy_tester import StrategyTester
+
+
+class DummyLoader:
+    def __init__(self):
+        self.called_with = None
+
+    def fetch_historical_data(self, symbol, interval, start, end):
+        self.called_with = (symbol, interval, start, end)
+        dates = pd.date_range('2024-01-01', periods=2)
+        return pd.DataFrame(
+            {
+                'open': [1, 1],
+                'high': [1, 1],
+                'low': [1, 1],
+                'close': [1, 1],
+                'volume': [1, 1],
+            },
+            index=dates,
+        )
+
+
+class DummyStrategy:
+    def __init__(self, p):
+        self.p = p
+        self.stop_loss_pct = 10 / 100
+        self.take_profit_pct = 20 / 100
+
+    def generate_signals(self, data):
+        return pd.Series(
+            [TradeAction.ENTER_LONG.value, TradeAction.EXIT.value], index=data.index
+        )
+
+
+class DummyReport(ReportGenerator):
+    def __init__(self, path):
+        super().__init__()
+        self.path = path
+
+    def generate_report(self, *args, **kwargs):
+        filename = kwargs.get('filename') or self.path
+        with open(filename, 'w') as f:
+            f.write('x')
+        self.generated = filename
+
+
+def test_strategy_tester(tmp_path):
+    loader = DummyLoader()
+    sm = StrategyManager(None, trade_mode=TradeMode.LONG_ONLY)
+    rg = DummyReport(tmp_path / 'report.pdf')
+    tester = StrategyTester(loader, sm, ResultAnalyzer(), rg)
+    params = {'p': 5}
+    results = tester.run(
+        DummyStrategy,
+        params,
+        'SYM',
+        '1d',
+        '2024-01-01',
+        '2024-01-02',
+        report_file=str(tmp_path / 'report.pdf'),
+    )
+    assert loader.called_with == ('SYM', '1d', '2024-01-01', '2024-01-02')
+    assert results['DummyStrategy']['params'] == params
+    assert os.path.exists(rg.generated)


### PR DESCRIPTION
## Summary
- implement `strategy_tester.py` to backtest a single strategy
- create test for the tester module
- mention strategy tester usage in README
- include `strategy_tester.py` in the README project structure

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684be4edecd0832181e3c1914b6b9aec