### PR TITLE
Add Markov entropy enhancements

### DIFF
--- a/config.py
+++ b/config.py
@@ -154,3 +154,18 @@ PRICE_BREAKOUT_VOLUME_RANGES = {
     ]
 }
 
+
+MARKOV_ENTROPY_RANGES = {
+    '4h': [
+        {'name': 'lookback_days', 'type': 'int', 'low': 30, 'high': 120, 'step': 10},
+        {'name': 'edge_threshold', 'type': 'float', 'low': 0.05, 'high': 0.5, 'step': 0.05},
+        {'name': 'entropy_threshold', 'type': 'float', 'low': 0.5, 'high': 2.5, 'step': 0.25},
+        {'name': 'stationary_threshold', 'type': 'float', 'low': 0.05, 'high': 0.3, 'step': 0.05},
+        {'name': 'kl_threshold', 'type': 'float', 'low': 0.0, 'high': 0.5, 'step': 0.05},
+        {'name': 'bucket_level', 'type': 'list', 'values': ['hour', '4h', 'session']},
+        {'name': 'label_scheme', 'type': 'list', 'values': ['fixed', 'vol', 'quantile']},
+        {'name': 'stop_loss_pct', 'type': 'float', 'low': 1, 'high': 3, 'step': 0.5},
+        {'name': 'take_profit_pct', 'type': 'float', 'low': 2, 'high': 10, 'step': 1}
+    ]
+}
+

--- a/main.py
+++ b/main.py
@@ -11,11 +11,13 @@ from strategies import (
     ZeroLagMACD_OBV_Strategy,
     EMACrossover,
     PriceBreakoutVolumeStrategy,
-    HyperScalper
+    HyperScalper,
+    MarkovEntropyStrategy
 )
 from config import (
     PRICE_BREAKOUT_VOLUME_RANGES,
-    HYPER_SCALPER_RANGES
+    HYPER_SCALPER_RANGES,
+    MARKOV_ENTROPY_RANGES
 )
 from binance.client import Client
 from utils.enums import TradeMode
@@ -57,7 +59,7 @@ def main():
         interval,
         start_time,
         end_time,
-        strategies=[HyperScalper],
+        strategies=[HyperScalper, MarkovEntropyStrategy],
         param_ranges={
             'MACD_RSIStrategy': [
                 {'name': 'macd_short_window', 'type': 'int', 'low': 5, 'high': 20},
@@ -140,7 +142,8 @@ def main():
                 {'name': 'take_profit_pct', 'type': 'int', 'low': 1, 'high': 4}
             ],
             'PriceBreakoutVolumeStrategy': PRICE_BREAKOUT_VOLUME_RANGES.get('5m'),
-            'HyperScalper': HYPER_SCALPER_RANGES.get('1d')
+            'HyperScalper': HYPER_SCALPER_RANGES.get('1d'),
+            'MarkovEntropyStrategy': MARKOV_ENTROPY_RANGES.get('4h')
         },
         n_iterations = num_iterations,
         train_ratio = train_ratio

--- a/optimization/utils.py
+++ b/optimization/utils.py
@@ -2,7 +2,20 @@ import random
 
 
 def clamp_value(val, spec):
-    """Clamp *val* to the range specified in *spec* and apply any step."""
+    """Clamp *val* to the range specified in *spec* and apply any step.
+
+    For ``type`` ``'list'`` the *val* represents an index into ``spec['values']``
+    and will be clamped to the valid range of indices.  The index is returned
+    without decoding so optimisers can continue to operate on numeric values.
+    """
+
+    if spec['type'] == 'list':
+        values = spec.get('values', [])
+        if not values:
+            raise ValueError("spec['values'] must contain at least one item")
+        idx = int(round(val))
+        return min(max(idx, 0), len(values) - 1)
+
     low, high = spec['low'], spec['high']
     step = spec.get('step')
     if step is not None:
@@ -28,6 +41,13 @@ def clamp_value(val, spec):
 
 def sample_value(spec):
     """Return a random value respecting type, range and step."""
+
+    if spec['type'] == 'list':
+        values = spec.get('values', [])
+        if not values:
+            raise ValueError("spec['values'] must contain at least one item")
+        return random.randint(0, len(values) - 1)
+
     low, high = spec['low'], spec['high']
     step = spec.get('step')
     if step is not None:
@@ -41,3 +61,15 @@ def sample_value(spec):
     else:
         val = random.uniform(low, high)
     return clamp_value(val, spec)
+
+
+def decode_value(val, spec):
+    """Decode *val* according to ``spec`` if it represents a list index."""
+    if spec['type'] == 'list':
+        values = spec.get('values', [])
+        if not values:
+            raise ValueError("spec['values'] must contain at least one item")
+        idx = int(round(val))
+        idx = min(max(idx, 0), len(values) - 1)
+        return values[idx]
+    return val

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -11,3 +11,4 @@ from .vwap_rsi_nolagmacd import VWAP_RSI_ZeroLagMACDStrategy
 from .obv_nolagmacd import ZeroLagMACD_OBV_Strategy
 from .price_breakout_volume import PriceBreakoutVolumeStrategy
 from .hyper_scalper import HyperScalper
+from .markov_entropy import MarkovEntropyStrategy

--- a/strategies/markov_entropy.py
+++ b/strategies/markov_entropy.py
@@ -1,0 +1,86 @@
+import pandas as pd
+import numpy as np
+from .base_strategy import Strategy
+from utils.enums import TradeAction
+from utils.markov_entropy import rolling_markov, calendar_bucket
+
+
+class MarkovEntropyStrategy(Strategy):
+    def __init__(
+        self,
+        lookback_days,
+        edge_threshold,
+        entropy_threshold,
+        stationary_threshold,
+        kl_threshold,
+        bucket_level="4h",
+        stop_loss_pct=1,
+        take_profit_pct=1,
+        label_scheme="fixed",
+    ):
+        super().__init__(stop_loss_pct, take_profit_pct)
+        self.lookback_days = int(lookback_days)
+        self.edge_threshold = float(edge_threshold)
+        self.entropy_threshold = float(entropy_threshold)
+        self.bucket_level = bucket_level
+        self.label_scheme = label_scheme
+        self.stationary_threshold = float(stationary_threshold)
+        self.kl_threshold = float(kl_threshold)
+
+    def generate_signals(self, data: pd.DataFrame) -> pd.Series:
+        metrics = rolling_markov(
+            data,
+            bucket_level=self.bucket_level,
+            window_days=self.lookback_days,
+            label_scheme=self.label_scheme,
+        )
+        if not metrics:
+            return pd.Series(TradeAction.EXIT.value, index=data.index)
+
+        latest_date = max(metrics)
+        current_bucket = calendar_bucket(
+            pd.DatetimeIndex([latest_date]), self.bucket_level
+        )[0]
+        m = metrics.get(latest_date, {}).get(current_bucket)
+        if m is None:
+            return pd.Series(TradeAction.EXIT.value, index=data.index)
+
+        edge = m["edge_vector"]
+        entropy_rate = m["entropy_rate"]
+        stationary = m["stationary"]
+        kl = m["kl_div"]
+
+        returns = np.log(data["close"]).diff()
+        current_ret = returns.iloc[-1]
+        current_label = pd.cut(
+            [current_ret], bins=m["bin_edges"], labels=False, right=False
+        )[0]
+
+        long_cond = (
+            edge.loc[current_label] > self.edge_threshold
+            and entropy_rate < self.entropy_threshold
+            and stationary.loc[current_label] > self.stationary_threshold
+            and (
+                pd.isna(kl.loc[current_label])
+                or kl.loc[current_label] < self.kl_threshold
+            )
+        )
+
+        short_cond = (
+            edge.loc[current_label] < -self.edge_threshold
+            and entropy_rate < self.entropy_threshold
+            and stationary.loc[current_label] > self.stationary_threshold
+            and (
+                pd.isna(kl.loc[current_label])
+                or kl.loc[current_label] < self.kl_threshold
+            )
+        )
+
+        if long_cond:
+            signal = TradeAction.ENTER_LONG.value
+        elif short_cond:
+            signal = TradeAction.ENTER_SHORT.value
+        else:
+            signal = TradeAction.EXIT.value
+
+        return pd.Series(signal, index=data.index)

--- a/tests/test_markov_entropy.py
+++ b/tests/test_markov_entropy.py
@@ -1,0 +1,53 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import pandas as pd
+from utils.enums import TradeAction
+from strategies.markov_entropy import MarkovEntropyStrategy
+
+
+def test_markov_entropy_long_signal():
+    dates = pd.date_range('2024-01-01', periods=360, freq='h')
+    close = [1.01 ** i for i in range(360)]
+    data = pd.DataFrame({
+        'open': close,
+        'high': close,
+        'low': close,
+        'close': close,
+        'volume': [1] * len(close),
+    }, index=dates)
+    strat = MarkovEntropyStrategy(
+        lookback_days=10,
+        edge_threshold=0.0,
+        entropy_threshold=1.0,
+        stationary_threshold=0.0,
+        kl_threshold=1.0,
+        bucket_level='hour',
+        stop_loss_pct=1,
+        take_profit_pct=1,
+    )
+    signals = strat.generate_signals(data)
+    assert list(signals) == [TradeAction.ENTER_LONG.value] * len(data)
+
+
+def test_markov_entropy_short_signal():
+    dates = pd.date_range('2024-01-01', periods=360, freq='h')
+    close = [1.01 ** i for i in reversed(range(360))]
+    data = pd.DataFrame({
+        'open': close,
+        'high': close,
+        'low': close,
+        'close': close,
+        'volume': [1] * len(close),
+    }, index=dates)
+    strat = MarkovEntropyStrategy(
+        lookback_days=10,
+        edge_threshold=0.0,
+        entropy_threshold=1.0,
+        stationary_threshold=0.0,
+        kl_threshold=1.0,
+        bucket_level='hour',
+        stop_loss_pct=1,
+        take_profit_pct=1,
+    )
+    signals = strat.generate_signals(data)
+    assert list(signals) == [TradeAction.ENTER_SHORT.value] * len(data)

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -8,6 +8,7 @@ from optimization.differential_evolution import DifferentialEvolutionOptimizer
 from optimization.particle_swarm import ParticleSwarmOptimizer
 from optimization.bayesian_optimization import BayesianOptimizer
 from optimization.hybrid_optimizer import ParallelHybridOptimizer
+from optimization.utils import decode_value
 
 # Simple quadratic objective with maximum at x=3
 param_ranges = [{'low': 0, 'high': 5, 'type': 'float'}]
@@ -75,4 +76,18 @@ def test_float_parameter_step_handling():
     result = ga.optimize(lambda p: -(p[0] - 0.75) ** 2, step_ranges, n_iterations=4)
     mod = (result[0] - step_ranges[0]['low']) % 0.25
     assert math.isclose(mod, 0.0, abs_tol=1e-8)
+
+
+def test_list_parameter_handling():
+    np.random.seed(0)
+    ga = GeneticAlgorithmOptimizer()
+    spec = {'type': 'list', 'values': [0, 5, 10]}
+
+    def obj(params):
+        val = decode_value(params[0], spec)
+        return -(val - 5) ** 2
+
+    result = ga.optimize(obj, [spec], n_iterations=4)
+    decoded = decode_value(result[0], spec)
+    assert decoded in spec['values']
 

--- a/trading_system_controller.py
+++ b/trading_system_controller.py
@@ -1,4 +1,5 @@
 import logging
+from optimization.utils import decode_value
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
@@ -12,6 +13,7 @@ class TradingSystemController:
         self.train_data = None
         self.test_data = None
         self.current_strategy_class = None
+        self.current_param_ranges = None
         self.objectives = ['sharpe_ratio']
         self.objective_weights = {'sharpe_ratio': 1.0}
     
@@ -40,7 +42,14 @@ class TradingSystemController:
             self.objective_weights = {obj: eq_weight for obj in self.objectives}
 
     def objective_function(self, params):
-        strategy = self.current_strategy_class(*params)
+        if self.current_param_ranges:
+            decoded = [
+                decode_value(val, spec)
+                for val, spec in zip(params, self.current_param_ranges)
+            ]
+        else:
+            decoded = params
+        strategy = self.current_strategy_class(*decoded)
         self.strategy_manager.reset(self.train_data)
         self.strategy_manager.execute_strategy(strategy)
         performance = self.result_analyzer.analyze(
@@ -113,6 +122,7 @@ class TradingSystemController:
         for strategy_class in strategies:
             logging.info(f"Optimizing {strategy_class.__name__}")
             self.current_strategy_class = strategy_class
+            self.current_param_ranges = param_ranges[strategy_class.__name__]
 
             fold_train_metrics = []
             fold_test_metrics = []
@@ -124,11 +134,15 @@ class TradingSystemController:
 
                 best_params = self.optimizer.optimize(
                     self.objective_function,
-                    param_ranges[strategy_class.__name__],
+                    self.current_param_ranges,
                     n_iterations,
                 )
 
-                best_strategy = strategy_class(*best_params)
+                decoded_params = [
+                    decode_value(val, spec)
+                    for val, spec in zip(best_params, self.current_param_ranges)
+                ]
+                best_strategy = strategy_class(*decoded_params)
 
                 self.strategy_manager.reset(train_data)
                 self.strategy_manager.execute_strategy(best_strategy)
@@ -162,8 +176,8 @@ class TradingSystemController:
                 avg_test["no_trades"] = True
 
             best_params_map = {
-                param["name"]: val
-                for param, val in zip(param_ranges[strategy_class.__name__], best_params)
+                param["name"]: decode_value(val, param)
+                for param, val in zip(self.current_param_ranges, best_params)
             }
 
             best_results[strategy_class.__name__] = {

--- a/utils/markov_entropy.py
+++ b/utils/markov_entropy.py
@@ -1,0 +1,176 @@
+import pandas as pd
+import numpy as np
+from typing import Iterable, List, Literal, Tuple, Dict
+from scipy.stats import entropy
+
+
+def _fixed_bins() -> List[float]:
+    return [-np.inf, -0.05, -0.02, -0.005, 0.005, 0.02, 0.05, np.inf]
+
+
+def _vol_scaled_bins(returns: pd.Series, mults: Iterable[float] = (-3, -2, -1, 1, 2, 3)) -> List[float]:
+    sig = returns.std(ddof=0)
+    if np.isnan(sig) or sig == 0:
+        raise ValueError("Volatility is zero – cannot build vol-scaled bins.")
+    edges = [-np.inf] + [m * sig for m in mults] + [np.inf]
+    return sorted(edges)
+
+
+def _quantile_bins(
+    returns: pd.Series,
+    quantiles: Iterable[float] = (0.01, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99),
+) -> List[float]:
+    qs = returns.quantile(list(quantiles)).to_list()
+    return [-np.inf] + qs + [np.inf]
+
+
+def choose_magnitude_bins(
+    returns: pd.Series,
+    scheme: Literal["fixed", "vol", "quantile"] = "fixed",
+    *,
+    mults: Iterable[float] | None = None,
+    quantiles: Iterable[float] | None = None,
+) -> List[float]:
+    if scheme == "fixed":
+        return _fixed_bins()
+    elif scheme == "vol":
+        return _vol_scaled_bins(returns, mults or (-3, -2, -1, 1, 2, 3))
+    elif scheme == "quantile":
+        return _quantile_bins(returns, quantiles or (0.01, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99))
+    else:
+        raise ValueError(f"Unknown bin scheme: {scheme}")
+
+
+def label_returns(
+    closes: pd.Series,
+    scheme: Literal["fixed", "vol", "quantile"] = "fixed",
+    lookback: int | None = None,
+    **kwargs,
+) -> Tuple[pd.Series, List[float]]:
+    log_ret = np.log(closes).diff()
+    calib_slice = log_ret.dropna() if lookback is None else log_ret.dropna().iloc[-lookback:]
+    edges = choose_magnitude_bins(calib_slice, scheme, **kwargs)
+    labels = pd.cut(log_ret, bins=edges, labels=False, right=False)
+    return labels, edges
+
+
+def calendar_bucket(
+    index: pd.DatetimeIndex,
+    level: Literal["week", "weekday", "hour", "4h", "session"] = "weekday",
+) -> pd.Index:
+    if level == "week":
+        return index.isocalendar().week.astype(int)
+    if level == "weekday":
+        return index.weekday
+    if level == "hour":
+        return index.hour
+    if level == "4h":
+        return (index.hour // 4)
+    if level == "session":
+        h = index.hour
+        labels = np.select(
+            [
+                (h >= 0) & (h < 7),
+                (h >= 7) & (h < 13),
+                (h >= 13) & (h < 20),
+                (h >= 20) & (h < 24),
+            ],
+            ["AS", "EU", "US", "AS"],
+            default="AS",
+        )
+        return pd.Series(labels, index=index)
+    raise ValueError(level)
+
+
+def markov_chain_metrics(
+    label_series: pd.Series,
+    bin_edges: list,
+    up_bins=None,
+    down_bins=None,
+    prev_matrix=None,
+) -> Dict[str, object]:
+    k = len(bin_edges) - 1
+    all_states = list(range(k))
+    up_bins = up_bins if up_bins is not None else [i for i in range(k) if i >= k // 2 + 1]
+    down_bins = down_bins if down_bins is not None else [i for i in range(k) if i <= k // 2 - 1]
+
+    src = label_series.shift(1).dropna()
+    dst = label_series.loc[src.index]
+    counts = pd.crosstab(src, dst)
+    counts = counts.reindex(index=all_states, columns=all_states, fill_value=0)
+    matrix = counts.div(counts.sum(axis=1), axis=0).fillna(0)
+
+    eigvals, eigvecs = np.linalg.eig(matrix.T)
+    ix = np.isclose(eigvals, 1)
+    if np.any(ix):
+        stationary = np.real(eigvecs[:, ix][:, 0])
+        stationary /= stationary.sum()
+        stationary = pd.Series(stationary, index=matrix.index)
+    else:
+        k = len(matrix)
+        stationary = pd.Series([1 / k] * k, index=matrix.index)
+
+    entropy_rate = sum(
+        stationary.get(i, 0) * entropy(matrix.loc[i], base=2)
+        if matrix.loc[i].sum() > 0 else 0
+        for i in matrix.index
+    )
+    non_triv = [e for e in np.real(eigvals) if not np.isclose(e, 1)]
+    spectral_gap = 1 - abs(max(non_triv, default=0))
+    self_persist = np.mean(np.diag(matrix.to_numpy()))
+    edge_vec = matrix[up_bins].sum(axis=1) - matrix[down_bins].sum(axis=1)
+
+    if prev_matrix is not None:
+        aligned_prev = prev_matrix.reindex_like(matrix).fillna(0)
+        frob = np.linalg.norm(matrix.to_numpy() - aligned_prev.to_numpy())
+        kl = matrix.apply(
+            lambda row: entropy(row, aligned_prev.loc[row.name], base=2)
+            if row.name in aligned_prev.index and row.sum() > 0 and aligned_prev.loc[row.name].sum() > 0
+            else np.nan,
+            axis=1,
+        )
+    else:
+        frob, kl = np.nan, pd.Series(np.nan, index=matrix.index)
+
+    return {
+        "P": matrix,
+        "counts": counts,
+        "stationary": stationary,
+        "entropy_rate": entropy_rate,
+        "spectral_gap": spectral_gap,
+        "self_stay": self_persist,
+        "edge_vector": edge_vec,
+        "frobenius": frob,
+        "kl_div": kl,
+        "bin_edges": bin_edges,
+    }
+
+
+def rolling_markov(
+    df: pd.DataFrame,
+    bucket_level: str = "weekday",
+    window_days: int = 90,
+    label_scheme: str = "fixed",
+    **label_kwargs,
+) -> Dict[pd.Timestamp, Dict[object, Dict[str, object]]]:
+    closes = df["close"].copy()
+    stride = 1
+    results: Dict[pd.Timestamp, Dict[object, Dict[str, object]]] = {}
+    prev_matrix = None
+    date_range = closes.index.normalize().unique()[window_days::stride]
+
+    for as_of in date_range:
+        window_start = as_of - pd.Timedelta(days=window_days)
+        sub = closes.loc[window_start:as_of]
+        labels, bin_edges = label_returns(sub, scheme=label_scheme, lookback=None, **label_kwargs)
+        key = calendar_bucket(labels.index, bucket_level)
+        joined = pd.DataFrame({"label": labels, "bucket": key}).dropna()
+
+        for b in joined["bucket"].unique():
+            sub_labels = joined.loc[joined["bucket"] == b, "label"]
+            if len(sub_labels) < 10:
+                continue
+            metrics = markov_chain_metrics(sub_labels, bin_edges, prev_matrix=prev_matrix)
+            results.setdefault(as_of, {})[b] = metrics
+            prev_matrix = metrics["P"]
+    return results


### PR DESCRIPTION
## Summary
- add parameter ranges for Markov entropy strategy
- use new strategy in the optimisation demo in `main.py`
- enhance `MarkovEntropyStrategy` with stationary and KL divergence filters
- update unit tests for revised logic

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pdfminer.six`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e38ad85a48321b95afe4218899873